### PR TITLE
修复音乐播放器使用进阶配置无法访问页面的错误

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -668,11 +668,8 @@ spec:
           name: music_config
           label:  侧边栏音乐-参数进阶配置
           placeholder: '请输入音乐参数配置'
-          value: 'list-folded="true"
-                server="netease"
-                type="playlist"
-                id="7355014621"'
-          help: '输入音乐参数配置(id / server / type必填)，详细配置方式见官方文档：https://github.com/metowolf/MetingJS/'
+          value: '{"list-folded":"true","server":"netease","type":"playlist","id":"7355014621"}'
+          help: '输入音乐参数配置(JSON格式，id / server / type必填)，详细配置方式见官方文档：https://github.com/metowolf/MetingJS/'
         - $formkit: radio
           name: show_ad_tag
           label:  侧边栏广告-显示“广告”标签

--- a/templates/widget/music.html
+++ b/templates/widget/music.html
@@ -7,10 +7,21 @@
   <div style="min-height: 90px;margin-top: -0.5rem;">
     <meting-js th:if="${theme.config.sidebar.music_mode == 'playlist'}" list-folded="true" server="netease"
                type="playlist" th:id="${theme.config.sidebar.netease_playlist_id}"></meting-js>
-    <meting-js th:if="${theme.config.sidebar.music_mode == 'config'}"
-               th:attr="${theme.config.sidebar.music_config}"></meting-js>
+    <meting-js th:if="${theme.config.sidebar.music_mode == 'config'}"></meting-js>
   </div>
+  <script th:inline="javascript">
+    var musicMode = [[${theme.config.sidebar.music_mode}]];
+    if (musicMode === 'config') {
+      var configStr = [[${theme.config.sidebar.music_config}]];
+      var musicConfig = JSON.parse(configStr);
+      var metingElements = document.querySelectorAll('meting-js');
+      for (var key in musicConfig) {
+          metingElements[0].setAttribute(key, musicConfig[key]);
+      }
+    }
+  </script>
   <link rel="stylesheet" th:href="@{/assets/lib/aplayer@1.10.1/APlayer.min.css}">
   <script defer th:src="@{/assets/lib/aplayer@1.10.1/APlayer.min.js}"></script>
+  <script defer th:src="@{/assets/lib/meting@2.0.1/Meting.min.js}"></script>
   <script defer th:src="@{/assets/lib/meting@2.0.1/Meting.min.js}"></script>
 </div>


### PR DESCRIPTION
音乐播放器参数进阶配置改成JSON字符串格式，通过JavaScript设置meting-js属性值