### PR TITLE
fix：增加信息模块统计项配置方式

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -595,7 +595,7 @@ spec:
           label: 侧边栏信息-统计
           placeholder: 'post|category|comment'
           value: post|category|comment
-          help: '最多可配置3个统计项，按输入顺序显示，缺失或错误配置则显示默认统计项，参数间用 “|” 分隔。visit：访问数量；upvote：点赞数量；comment：评论数量；post：文章数量；category：分类数量'
+          help: '最多可配置3个统计项，按输入顺序显示，缺失或错误配置则显示默认统计项，参数间用 “|” 分隔。visit：访问数量；upvote：点赞数量；comment：评论数量；post：文章数量；category：分类数量。'
         - $formkit: text
           name: profile_theme_button
           label: 侧边栏信息-主题按钮

--- a/settings.yaml
+++ b/settings.yaml
@@ -591,6 +591,12 @@ spec:
           label: 侧边栏信息-地理位置
           placeholder: '请输入个人所在地'
         - $formkit: text
+          name: profile_theme_stats
+          label: 侧边栏信息-统计
+          placeholder: 'post|category|comment'
+          value: post|category|comment
+          help: '请输入3个统计项，按顺序排布，参数间用 “|” 分隔。visit：访问数量；upvote：点赞数量；comment：评论数量；post：文章数量；category：分类数量'
+        - $formkit: text
           name: profile_theme_button
           label: 侧边栏信息-主题按钮
           placeholder: '按钮名称|按钮地址'

--- a/settings.yaml
+++ b/settings.yaml
@@ -595,7 +595,7 @@ spec:
           label: 侧边栏信息-统计
           placeholder: 'post|category|comment'
           value: post|category|comment
-          help: '请输入3个统计项，按顺序排布，参数间用 “|” 分隔。visit：访问数量；upvote：点赞数量；comment：评论数量；post：文章数量；category：分类数量'
+          help: '最多可配置3个统计项，按输入顺序显示，缺失或错误配置则显示默认统计项，参数间用 “|” 分隔。visit：访问数量；upvote：点赞数量；comment：评论数量；post：文章数量；category：分类数量'
         - $formkit: text
           name: profile_theme_button
           label: 侧边栏信息-主题按钮

--- a/templates/widget/profile.html
+++ b/templates/widget/profile.html
@@ -15,23 +15,47 @@
         </p>
       </div>
     </nav>
-    <nav class="level">
+    <nav class="level" th:with="statsItems = ${#strings.arraySplit(theme.config.sidebar.profile_theme_stats,'|')}">
       <div class="level-item">
         <div>
-          <p class="heading">文章</p>
-          <p class="value" th:text="${stats.post}"></p>
+          <p th:if="${statsItems.length>=1 && statsItems[0] == 'visit'}" class="heading">访问</p>
+		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'upvote'}" class="heading">点赞</p>
+		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'comment'}" class="heading">评论</p>
+		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'post'}" class="heading">文章</p>
+		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'category'}" class="heading">分类</p>
+		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'visit'}" class="value" th:text="${stats.visit}"></p>
+		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'upvote'}" class="value" th:text="${stats.upvote}"></p>
+		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'comment'}" class="value" th:text="${stats.comment}"></p>
+		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'post'}" class="value" th:text="${stats.post}"></p>
+		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'category'}" class="value" th:text="${stats.category}"></p>
         </div>
       </div>
       <div class="level-item has-text-centered is-marginless">
         <div>
-          <p class="heading">分类</p>
-          <p class="value" th:text="${stats.category}"></p>
+          <p th:if="${statsItems.length>=2 && statsItems[1] == 'visit'}" class="heading">访问</p>
+		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'upvote'}" class="heading">点赞</p>
+		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'comment'}" class="heading">评论</p>
+		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'post'}" class="heading">文章</p>
+		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'category'}" class="heading">分类</p>
+		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'visit'}" class="value" th:text="${stats.visit}"></p>
+		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'upvote'}" class="value" th:text="${stats.upvote}"></p>
+		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'comment'}" class="value" th:text="${stats.comment}"></p>
+		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'post'}" class="value" th:text="${stats.post}"></p>
+		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'category'}" class="value" th:text="${stats.category}"></p>
         </div>
       </div>
       <div class="level-item">
         <div>
-          <p class="heading">评论</p>
-          <p class="value" th:text="${stats.comment}"></p>
+          <p th:if="${statsItems.length>=3 && statsItems[2] == 'visit'}" class="heading">访问</p>
+		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'upvote'}" class="heading">点赞</p>
+		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'comment'}" class="heading">评论</p>
+		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'post'}" class="heading">文章</p>
+		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'category'}" class="heading">分类</p>
+		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'visit'}" class="value" th:text="${stats.visit}"></p>
+		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'upvote'}" class="value" th:text="${stats.upvote}"></p>
+		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'comment'}" class="value" th:text="${stats.comment}"></p>
+		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'post'}" class="value" th:text="${stats.post}"></p>
+		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'category'}" class="value" th:text="${stats.category}"></p>
         </div>
       </div>
     </nav>

--- a/templates/widget/profile.html
+++ b/templates/widget/profile.html
@@ -16,46 +16,70 @@
       </div>
     </nav>
     <nav class="level" th:with="statsItems = ${#strings.arraySplit(theme.config.sidebar.profile_theme_stats,'|')}">
-      <div class="level-item">
-        <div>
-          <p th:if="${statsItems.length>=1 && statsItems[0] == 'visit'}" class="heading">访问</p>
-		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'upvote'}" class="heading">点赞</p>
-		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'comment'}" class="heading">评论</p>
-		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'post'}" class="heading">文章</p>
-		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'category'}" class="heading">分类</p>
-		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'visit'}" class="value" th:text="${stats.visit}"></p>
-		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'upvote'}" class="value" th:text="${stats.upvote}"></p>
-		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'comment'}" class="value" th:text="${stats.comment}"></p>
-		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'post'}" class="value" th:text="${stats.post}"></p>
-		  <p th:if="${statsItems.length>=1 && statsItems[0] == 'category'}" class="value" th:text="${stats.category}"></p>
+      <div class="level-item" th:switch="${statsItems.length>=1?statsItems[0]:'post'}">
+        <div th:case="visit">
+          <p class="heading">访问</p>
+          <p class="value" th:text="${stats.visit}"></p>
+        </div>
+        <div th:case="upvote">
+          <p class="heading">点赞</p>
+          <p class="value" th:text="${stats.upvote}"></p>
+        </div>
+        <div th:case="comment">
+          <p class="heading">评论</p>
+          <p class="value" th:text="${stats.comment}"></p>
+        </div>
+        <div th:case="category">
+          <p class="heading">分类</p>
+          <p class="value" th:text="${stats.category}"></p>
+        </div>
+        <div th:case="*">
+          <p class="heading">文章</p>
+          <p class="value" th:text="${stats.post}"></p>
         </div>
       </div>
-      <div class="level-item has-text-centered is-marginless">
-        <div>
-          <p th:if="${statsItems.length>=2 && statsItems[1] == 'visit'}" class="heading">访问</p>
-		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'upvote'}" class="heading">点赞</p>
-		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'comment'}" class="heading">评论</p>
-		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'post'}" class="heading">文章</p>
-		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'category'}" class="heading">分类</p>
-		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'visit'}" class="value" th:text="${stats.visit}"></p>
-		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'upvote'}" class="value" th:text="${stats.upvote}"></p>
-		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'comment'}" class="value" th:text="${stats.comment}"></p>
-		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'post'}" class="value" th:text="${stats.post}"></p>
-		  <p th:if="${statsItems.length>=2 && statsItems[1] == 'category'}" class="value" th:text="${stats.category}"></p>
+      <div class="level-item has-text-centered is-marginless" th:with="statsItem = 'category'" th:switch="${statsItems.length>=2?statsItems[1]:'category'}">
+        <div th:case="visit">
+          <p class="heading">访问</p>
+          <p class="value" th:text="${stats.visit}"></p>
+        </div>
+        <div th:case="upvote">
+          <p class="heading">点赞</p>
+          <p class="value" th:text="${stats.upvote}"></p>
+        </div>
+        <div th:case="comment">
+          <p class="heading">评论</p>
+          <p class="value" th:text="${stats.comment}"></p>
+        </div>
+        <div th:case="post">
+          <p class="heading">文章</p>
+          <p class="value" th:text="${stats.post}"></p>
+        </div>
+        <div th:case="*">
+          <p class="heading">分类</p>
+          <p class="value" th:text="${stats.category}"></p>
         </div>
       </div>
-      <div class="level-item">
-        <div>
-          <p th:if="${statsItems.length>=3 && statsItems[2] == 'visit'}" class="heading">访问</p>
-		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'upvote'}" class="heading">点赞</p>
-		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'comment'}" class="heading">评论</p>
-		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'post'}" class="heading">文章</p>
-		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'category'}" class="heading">分类</p>
-		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'visit'}" class="value" th:text="${stats.visit}"></p>
-		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'upvote'}" class="value" th:text="${stats.upvote}"></p>
-		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'comment'}" class="value" th:text="${stats.comment}"></p>
-		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'post'}" class="value" th:text="${stats.post}"></p>
-		  <p th:if="${statsItems.length>=3 && statsItems[2] == 'category'}" class="value" th:text="${stats.category}"></p>
+      <div class="level-item" th:with="statsItem = 'comment'" th:switch="${statsItems.length>=3?statsItems[2]:'comment'}">
+        <div th:case="visit">
+          <p class="heading">访问</p>
+          <p class="value" th:text="${stats.visit}"></p>
+        </div>
+        <div th:case="upvote">
+          <p class="heading">点赞</p>
+          <p class="value" th:text="${stats.upvote}"></p>
+        </div>
+        <div th:case="post">
+          <p class="heading">文章</p>
+          <p class="value" th:text="${stats.post}"></p>
+        </div>
+        <div th:case="category">
+          <p class="heading">分类</p>
+          <p class="value" th:text="${stats.category}"></p>
+        </div>
+        <div th:case="*">
+          <p class="heading">评论</p>
+          <p class="value" th:text="${stats.comment}"></p>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
**fix:**
- 信息模块统计项默认显示：文章、分类、评论；
- 信息模块统计项配置在后台-主题设置-侧边栏配置-侧边栏信息-地理位置配置项下方，如下图；
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/e4668ebc-94c1-428d-90a5-bcdb81182d7d)
- 配置项最多显示3项，配置多出的无效；
- 配置项先后顺序即为显示的顺序；
- 配置项以“|”区分，少于3项时，按照有效配置项显示，缺失的项按照默认规则顺序（文章、分类、评论）显示，缺失哪项即在该位置显示默认统计项；
- 配置项名称错误时，按照默认规则顺序（文章、分类、评论）显示，哪项错误即在该位置显示默认统计项；
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/3ce39d3e-c2be-4a69-badb-fbb03cd63d19)
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/8190a2d0-6e5d-4553-aa54-455103e52e15)
- 统计项配置允许配置显示相同统计，即可以显示为下图；
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/1178bf93-5725-4cd1-b0c3-c0a9ef624569)

关联 #59 #60 