### PR TITLE
fix：增加信息模块统计项配置

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -590,6 +590,30 @@ spec:
           name: profile_location
           label: 侧边栏信息-地理位置
           placeholder: '请输入个人所在地'
+        - $formkit: repeater
+          name: custom_stats
+          label: 侧边栏信息-统计
+          help: 可配置0-3个统计项，不满足三项时缺失的位置显示默认统计项。
+          value:
+            - type: post
+            - type: category
+            - type: comment
+          children:
+            - $formkit: select
+              name: type
+              label: 统计项
+              value: ""
+              options:
+                - value: 'post'
+                  label:  文章数量
+                - value: 'category'
+                  label:  分类数量
+                - value: 'comment'
+                  label:  评论数量
+                - value: 'upvote'
+                  label:  点赞数量
+                - value: 'visit'
+                  label:  访问数量
         - $formkit: text
           name: profile_theme_button
           label: 侧边栏信息-主题按钮

--- a/templates/widget/profile.html
+++ b/templates/widget/profile.html
@@ -16,7 +16,7 @@
       </div>
     </nav>
     <nav class="level">
-      <div class="level-item" th:switch="${#lists.size(theme.config.sidebar.custom_stats)>=1?theme.config.sidebar.custom_stats[0].type:'post'}">
+      <div class="level-item" th:switch="${!#lists.isEmpty(theme.config.sidebar.custom_stats)&&#lists.size(theme.config.sidebar.custom_stats)>=1?theme.config.sidebar.custom_stats[0].type:'post'}">
         <div th:case="visit">
           <p class="heading">访问</p>
           <p class="value" th:text="${stats.visit}"></p>
@@ -38,7 +38,7 @@
           <p class="value" th:text="${stats.post}"></p>
         </div>
       </div>
-      <div class="level-item has-text-centered is-marginless" th:switch="${#lists.size(theme.config.sidebar.custom_stats)>=2?theme.config.sidebar.custom_stats[1].type:'category'}">
+      <div class="level-item has-text-centered is-marginless" th:switch="${!#lists.isEmpty(theme.config.sidebar.custom_stats)&&#lists.size(theme.config.sidebar.custom_stats)>=2?theme.config.sidebar.custom_stats[1].type:'category'}">
         <div th:case="visit">
           <p class="heading">访问</p>
           <p class="value" th:text="${stats.visit}"></p>
@@ -60,7 +60,7 @@
           <p class="value" th:text="${stats.category}"></p>
         </div>
       </div>
-      <div class="level-item" th:switch="${#lists.size(theme.config.sidebar.custom_stats)>=3?theme.config.sidebar.custom_stats[2].type:'comment'}">
+      <div class="level-item" th:switch="${!#lists.isEmpty(theme.config.sidebar.custom_stats)&&#lists.size(theme.config.sidebar.custom_stats)>=3?theme.config.sidebar.custom_stats[2].type:'comment'}">
         <div th:case="visit">
           <p class="heading">访问</p>
           <p class="value" th:text="${stats.visit}"></p>

--- a/templates/widget/profile.html
+++ b/templates/widget/profile.html
@@ -16,20 +16,68 @@
       </div>
     </nav>
     <nav class="level">
-      <div class="level-item">
-        <div>
+      <div class="level-item" th:switch="${#lists.size(theme.config.sidebar.custom_stats)>=1?theme.config.sidebar.custom_stats[0].type:'post'}">
+        <div th:case="visit">
+          <p class="heading">访问</p>
+          <p class="value" th:text="${stats.visit}"></p>
+        </div>
+        <div th:case="upvote">
+          <p class="heading">点赞</p>
+          <p class="value" th:text="${stats.upvote}"></p>
+        </div>
+        <div th:case="comment">
+          <p class="heading">评论</p>
+          <p class="value" th:text="${stats.comment}"></p>
+        </div>
+        <div th:case="category">
+          <p class="heading">分类</p>
+          <p class="value" th:text="${stats.category}"></p>
+        </div>
+        <div th:case="*">
           <p class="heading">文章</p>
           <p class="value" th:text="${stats.post}"></p>
         </div>
       </div>
-      <div class="level-item has-text-centered is-marginless">
-        <div>
+      <div class="level-item has-text-centered is-marginless" th:switch="${#lists.size(theme.config.sidebar.custom_stats)>=2?theme.config.sidebar.custom_stats[1].type:'category'}">
+        <div th:case="visit">
+          <p class="heading">访问</p>
+          <p class="value" th:text="${stats.visit}"></p>
+        </div>
+        <div th:case="upvote">
+          <p class="heading">点赞</p>
+          <p class="value" th:text="${stats.upvote}"></p>
+        </div>
+        <div th:case="comment">
+          <p class="heading">评论</p>
+          <p class="value" th:text="${stats.comment}"></p>
+        </div>
+        <div th:case="post">
+          <p class="heading">文章</p>
+          <p class="value" th:text="${stats.post}"></p>
+        </div>
+        <div th:case="*">
           <p class="heading">分类</p>
           <p class="value" th:text="${stats.category}"></p>
         </div>
       </div>
-      <div class="level-item">
-        <div>
+      <div class="level-item" th:switch="${#lists.size(theme.config.sidebar.custom_stats)>=3?theme.config.sidebar.custom_stats[2].type:'comment'}">
+        <div th:case="visit">
+          <p class="heading">访问</p>
+          <p class="value" th:text="${stats.visit}"></p>
+        </div>
+        <div th:case="upvote">
+          <p class="heading">点赞</p>
+          <p class="value" th:text="${stats.upvote}"></p>
+        </div>
+        <div th:case="post">
+          <p class="heading">文章</p>
+          <p class="value" th:text="${stats.post}"></p>
+        </div>
+        <div th:case="category">
+          <p class="heading">分类</p>
+          <p class="value" th:text="${stats.category}"></p>
+        </div>
+        <div th:case="*">
           <p class="heading">评论</p>
           <p class="value" th:text="${stats.comment}"></p>
         </div>


### PR DESCRIPTION
- 统计项默认显示：文章、分类、评论

### fix
- 主题配置增加统计项配置，如下图；
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/c28a1ddf-4b8d-4442-b745-33a698836057)
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/178b8506-0704-47a8-bdb7-8161101beccc)

### 注意：
- 配置项仅前三项有效，且允许重复；
- 配置项按顺序依次替换默认显示：文章、分类、评论，配置不满足三项时在缺失的位置上显示原本默认统计项，如下图；
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/bb613098-9c0b-48d5-b619-0fb752024844)
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/cb2d179e-518f-4fc8-898e-fbbb792d3397)

