### PR TITLE
feat：增加打赏开关总控制以及文章和页面独立控制

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -69,6 +69,18 @@ spec:
           label:  关闭
         - value: ""
           label:  跟随默认配置
+    - $formkit: radio
+      name: enable_donate
+      label:  开启文章打赏
+      value: ""
+      help: '当前配置将覆盖主题中的默认配置。'
+      options:
+        - value: "true"
+          label:  开启
+        - value: "false"
+          label:  关闭
+        - value: ""
+          label:  跟随默认配置
 
 ---
 
@@ -114,6 +126,18 @@ spec:
     - $formkit: radio
       name: enable_share
       label:  开启文章分享
+      value: ""
+      help: '当前配置将覆盖主题中的默认配置。'
+      options:
+        - value: "true"
+          label:  开启
+        - value: "false"
+          label:  关闭
+        - value: ""
+          label:  跟随默认配置
+    - $formkit: radio
+      name: enable_donate
+      label:  开启文章打赏
       value: ""
       help: '当前配置将覆盖主题中的默认配置。'
       options:

--- a/settings.yaml
+++ b/settings.yaml
@@ -502,6 +502,16 @@ spec:
               label:  默认开启
             - value: false
               label:  默认关闭
+        - $formkit: radio
+          name: enable_post_donate
+          label:  开启文章打赏
+          value: true
+          help: '如果文章或页面元数据配置了enable_donate项，则当前配置将被覆盖。'
+          options:
+            - value: true
+              label:  默认开启
+            - value: false
+              label:  默认关闭
         - $formkit: attachment
           name: donate_alipay
           label: 支付宝捐赠二维码

--- a/templates/main/admire.html
+++ b/templates/main/admire.html
@@ -1,5 +1,5 @@
 <th:block xmlns:th="https://www.thymeleaf.org"
-     th:with="donate=${!#strings.isEmpty(theme.config.post.donate_alipay) || !#strings.isEmpty(theme.config.post.donate_wechat)}">
+     th:with="donate=${enableDonate && (!#strings.isEmpty(theme.config.post.donate_alipay) || !#strings.isEmpty(theme.config.post.donate_wechat))}">
     <div th:if="${donate || type == 'Post'}" class="admire">
         <div class="admire-content">
             <button th:if="${donate}" class="donate">

--- a/templates/page.html
+++ b/templates/page.html
@@ -3,5 +3,6 @@
           th:insert="~{common/layout :: layout (title = ${singlePage.spec.title + ' - ' + site.title}, canonical = ${singlePage.status.permalink}, content = ~{main/article :: article (${singlePage}, 'SinglePage')}, isPost = true)}"
           th:with="enableKatex = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_katex'))? singlePage.metadata.annotations.get('enable_katex') : theme.config.post.enable_katex},
       enableShare = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_share'))? singlePage.metadata.annotations.get('enable_share') : theme.config.post.enable_post_share},
-      enableCopyright = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_copyright'))? singlePage.metadata.annotations.get('enable_copyright') : theme.config.post.enable_copyright}">
+      enableCopyright = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_copyright'))? singlePage.metadata.annotations.get('enable_copyright') : theme.config.post.enable_copyright},
+      enableDonate = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_donate'))? singlePage.metadata.annotations.get('enable_donate') : theme.config.post.enable_post_donate}">
 </th:block>

--- a/templates/post.html
+++ b/templates/post.html
@@ -3,5 +3,6 @@
           th:insert="~{common/layout :: layout (title = ${post.spec.title + ' - ' + site.title}, canonical = ${post.status.permalink}, content = ~{main/article :: article (${post}, 'Post')}, isPost = true)}"
           th:with="enableKatex = ${!#strings.isEmpty(post.metadata.annotations.get('enable_katex'))? post.metadata.annotations.get('enable_katex') : theme.config.post.enable_katex},
       enableShare = ${!#strings.isEmpty(post.metadata.annotations.get('enable_share'))? post.metadata.annotations.get('enable_share') : theme.config.post.enable_post_share},
-      enableCopyright = ${!#strings.isEmpty(post.metadata.annotations.get('enable_copyright'))? post.metadata.annotations.get('enable_copyright') : theme.config.post.enable_copyright}">
+      enableCopyright = ${!#strings.isEmpty(post.metadata.annotations.get('enable_copyright'))? post.metadata.annotations.get('enable_copyright') : theme.config.post.enable_copyright},
+      enableDonate = ${!#strings.isEmpty(post.metadata.annotations.get('enable_donate'))? post.metadata.annotations.get('enable_donate') : theme.config.post.enable_post_donate}">
 </th:block>


### PR DESCRIPTION
- 主题-文章 设置的总控开关，须确保微信和支付宝至少配置一项：
- ![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/0fc51241-8315-409a-861b-f64124a30bf1)

- 文章设置的独立开关，须开启总控开关：
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/39fe9e2d-5b15-44fa-b4f2-0ebecd46cfc5)

- 页面设置的独立开关，须开启总控开关：
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/af057eb6-266e-4ff6-9a0f-0262d729448b)
