### PR TITLE
feat：新增评论功能受站点评论开关与文章或页面评论开关控制

### DIFF
--- a/templates/common/scripts.html
+++ b/templates/common/scripts.html
@@ -15,7 +15,7 @@
     </th:block>
     <script th:if="${isPhotos}" data-pjax th:src="@{/assets/lib/justifiedGallery@3.8.1/jquery.justifiedGallery.min.js}"></script>
     <th:block th:if="${isPost || enableComment != null}">
-        <script th:if="${pluginFinder.available('PluginCommentWidget') && (post != null || singlePage != null || enableComment != null)}" data-pjax src="/plugins/PluginCommentWidget/assets/static/comment-widget.iife.js"></script>
+        <script th:if="${enableComment}" data-pjax src="/plugins/PluginCommentWidget/assets/static/comment-widget.iife.js"></script>
     </th:block>
 
     <script th:src="@{/assets/js/mew-custom.min.js(mew=${theme.spec.version})}"></script>

--- a/templates/links.html
+++ b/templates/links.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <th:block xmlns:th="https://www.thymeleaf.org"
           th:insert="~{common/layout :: layout (title = '友链 - ' + ${site.title}, canonical = @{/links}, content = ~{::content}, isPost = false)}"
-          th:with="enableComment = ${!#strings.isEmpty(theme.config.page_config.link_comment_id)}">
+          th:with="enableComment = ${!#strings.isEmpty(theme.config.page_config.link_comment_id) && site.comment.enable && pluginFinder.available('PluginCommentWidget')}">
     <th:block th:fragment="content"
               th:with="defaultAvatar = ${#strings.defaultString(theme.config.page_config.links_default_avatar, #theme.assets('/img/avatar.svg'))}">
         <div class="card">
@@ -46,7 +46,7 @@
                 </div>
             </div>
         </div>
-        <div class="card card-content" id="comment-wrapper" th:if="${pluginFinder.available('PluginCommentWidget') && enableComment}">
+        <div class="card card-content" id="comment-wrapper" th:if="${enableComment}">
             <h3 class="comment-title">评论</h3>
             <div class="widget-comment" th:data-id="${theme.config.page_config.link_comment_id}" data-target="SinglePage"></div>
         </div>

--- a/templates/main/article.html
+++ b/templates/main/article.html
@@ -89,7 +89,7 @@
         </div>
     </th:block>
 
-    <div class="card card-content" id="comment-wrapper" th:if="${pluginFinder.available('PluginCommentWidget')}">
+    <div class="card card-content" id="comment-wrapper" th:if="${enableComment}">
         <h3 class="comment-title">评论</h3>
         <div class="widget-comment" th:data-id="${post.metadata.name}" th:data-target="${type}"></div>
     </div>

--- a/templates/moments.html
+++ b/templates/moments.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <th:block
   th:insert="~{common/layout :: layout (title = '瞬间 - ' + ${site.title}, canonical = @{/moments}, content = ~{::content}, isPost = true)}"
-  th:with="isJournals = true, enableShare = ${theme.config.post.enable_post_share}, enableComment = ${theme.config.page_config.enable_journals_comment}"
+  th:with="isJournals = true, enableShare = ${theme.config.post.enable_post_share},
+           enableComment = ${theme.config.page_config.enable_journals_comment && site.comment.enable && pluginFinder.available('PluginCommentWidget')}"
   xmlns:th="https://www.thymeleaf.org">
   <th:block th:fragment="content">
     <div class="card card-content journal" th:each="moment : ${moments.items}">
@@ -37,7 +38,7 @@
           <a class="share"><i class="ri-share-forward-line"></i><em>分享</em></a>
         </span>
       </div>
-      <div class="journal-comment" th:if="${enableComment && pluginFinder.available('PluginCommentWidget')}">
+      <div class="journal-comment" th:if="${enableComment}">
         <div class="widget-comment" data-target="Moment" th:data-id="${moment.metadata.name}"></div>
       </div>
     </div>

--- a/templates/page.html
+++ b/templates/page.html
@@ -4,5 +4,6 @@
           th:with="enableKatex = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_katex'))? singlePage.metadata.annotations.get('enable_katex') : theme.config.post.enable_katex},
       enableShare = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_share'))? singlePage.metadata.annotations.get('enable_share') : theme.config.post.enable_post_share},
       enableCopyright = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_copyright'))? singlePage.metadata.annotations.get('enable_copyright') : theme.config.post.enable_copyright},
-      enableDonate = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_donate'))? singlePage.metadata.annotations.get('enable_donate') : theme.config.post.enable_post_donate}">
+      enableDonate = ${!#strings.isEmpty(singlePage.metadata.annotations.get('enable_donate'))? singlePage.metadata.annotations.get('enable_donate') : theme.config.post.enable_post_donate},
+      enableComment = ${site.comment.enable && pluginFinder.available('PluginCommentWidget') && singlePage.spec.allowComment}">
 </th:block>

--- a/templates/post.html
+++ b/templates/post.html
@@ -4,5 +4,6 @@
           th:with="enableKatex = ${!#strings.isEmpty(post.metadata.annotations.get('enable_katex'))? post.metadata.annotations.get('enable_katex') : theme.config.post.enable_katex},
       enableShare = ${!#strings.isEmpty(post.metadata.annotations.get('enable_share'))? post.metadata.annotations.get('enable_share') : theme.config.post.enable_post_share},
       enableCopyright = ${!#strings.isEmpty(post.metadata.annotations.get('enable_copyright'))? post.metadata.annotations.get('enable_copyright') : theme.config.post.enable_copyright},
-      enableDonate = ${!#strings.isEmpty(post.metadata.annotations.get('enable_donate'))? post.metadata.annotations.get('enable_donate') : theme.config.post.enable_post_donate}">
+      enableDonate = ${!#strings.isEmpty(post.metadata.annotations.get('enable_donate'))? post.metadata.annotations.get('enable_donate') : theme.config.post.enable_post_donate},
+      enableComment = ${site.comment.enable && pluginFinder.available('PluginCommentWidget') && post.spec.allowComment}">
 </th:block>


### PR DESCRIPTION
#64
- 站点的评论开关与是否安装评论插件优先级最高，关闭或未装插件，则不会显示评论功能；
- 支持文章设置中独立关闭评论功能；
- 支持页面设置中独立关闭评论功能；
- 友情链接页面在主题 - 页面设置中设置了“友链页面-评论区ID”时，现在可以受站点的评论关闭而关闭；
- 瞬间页面在主题 - 页面设置中“日志页面-开启评论”区开启时，现在可以受站点的评论关闭而关闭；

### 另外发现的问题 @nineya 

> - 瞬间页面的评论受页面设置的“日志页面-开启评论区”控制，配置中是否应该改为“瞬间页面-开启评论区”？
> - 瞬间页面的分享受页面设置的“文章设置-开启文章分享”控制，是否是字段引用错误，且页面设置中的“日志页面-开启日志分享”改为“瞬间页面-开启分享”？