### PR TITLE
fix：修复友链关联作者而不是站点信息 

### DIFF
--- a/templates/links.html
+++ b/templates/links.html
@@ -33,7 +33,7 @@
                     </th:block>
                     <hr th:if="${theme.config.page_config.show_exchange_info || !#strings.isEmpty(theme.config.page_config.links_info)}"/>
                     <th:block th:if="${theme.config.page_config.show_exchange_info}"
-                              th:with="bloggerAvatar= ${#strings.defaultString(theme.config.page_config.links_blogger_avatar, ((#strings.endsWith(site.url, '/') ? #strings.substring(site.url, 0, #strings.length(site.url) - 1) : site.url) + site.favicon))}">
+                              th:with="bloggerAvatar= ${#strings.defaultString(theme.config.page_config.links_blogger_avatar, #strings.startsWith(site.favicon, 'http') ? site.favicon : ((#strings.endsWith(site.url, '/') ? #strings.substring(site.url, 0, #strings.length(site.url) - 1) : site.url) + site.favicon))}">
                         申请友链的方法：
                         <ul>
                             <li>名称：[[${site.title}]]</li>

--- a/templates/links.html
+++ b/templates/links.html
@@ -33,7 +33,7 @@
                     </th:block>
                     <hr th:if="${theme.config.page_config.show_exchange_info || !#strings.isEmpty(theme.config.page_config.links_info)}"/>
                     <th:block th:if="${theme.config.page_config.show_exchange_info}"
-                              th:with="bloggerAvatar= ${#strings.defaultString(theme.config.page_config.links_blogger_avatar, site.favicon)}">
+                              th:with="bloggerAvatar= ${#strings.defaultString(theme.config.page_config.links_blogger_avatar, ((#strings.endsWith(site.url, '/') ? #strings.substring(site.url, 0, #strings.length(site.url) - 1) : site.url) + site.favicon))}">
                         申请友链的方法：
                         <ul>
                             <li>名称：[[${site.title}]]</li>

--- a/templates/links.html
+++ b/templates/links.html
@@ -8,7 +8,7 @@
             <div th:if="${!#strings.isEmpty(theme.config.page_config.links_thumbnail)}" class="card-image cover-image" th:style="'background-image: url(' + ${theme.config.page_config.links_thumbnail} + ')'">
             </div>
             <div class="card-content main">
-                <h1 class="title" th:text="'友情链接 - ' + ${contributor.displayName} + '的小伙伴们'"></h1>
+                <h1 class="title" th:text="'友情链接 - ' + ${site.title} + '的小伙伴们'"></h1>
                 <div class="main-content">
                     <th:block th:each="group : ${groups}">
                         <div th:if="${!#lists.isEmpty(group.links)}" class="links">
@@ -33,13 +33,13 @@
                     </th:block>
                     <hr th:if="${theme.config.page_config.show_exchange_info || !#strings.isEmpty(theme.config.page_config.links_info)}"/>
                     <th:block th:if="${theme.config.page_config.show_exchange_info}"
-                              th:with="bloggerAvatar= ${#strings.defaultString(theme.config.page_config.links_blogger_avatar, contributor.avatar)}">
+                              th:with="bloggerAvatar= ${#strings.defaultString(theme.config.page_config.links_blogger_avatar, site.favicon)}">
                         申请友链的方法：
                         <ul>
                             <li>名称：[[${site.title}]]</li>
                             <li>地址：<a th:href="${site.url}" th:text="${site.url}"></a></li>
                             <li>图标：<a th:href="${bloggerAvatar}" th:text="${bloggerAvatar}"></a></li>
-                            <li>描述：[[${contributor.bio}]]</li>
+                            <li>描述：[[${site.seo.description}]]</li>
                         </ul>
                     </th:block>
                     <div th:if="${!#strings.isEmpty(theme.config.page_config.links_info)}" th:utext="${theme.config.page_config.links_info}"></div>


### PR DESCRIPTION
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/d228bf89-3ed6-40e7-9c41-b262be2687e9)

1. 关联站点标题而不是作者用户名；
2. 若主题设置“页面设置 - 友链页面-交换信息自定义 Logo 链接”未配置则显示站点“基本设置 - Favicon”；
3. 关联站点“SEO 设置 - 站点描述”内容。

**原本关联作者头像和用户名，现修改为关联站点，若原本是设计如此，则取消此PR**

#69