### PR TITLE
feat：添加开关友链评论区功能

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -871,6 +871,15 @@ spec:
           label: "友链页面-补充信息"
           placeholder: '请输入补充信息'
           help: '友链页面最低部的补充说明信息，支持 HTML 格式。'
+        - $formkit: radio
+          name: link_comment_enable
+          label:  友链页面-开启评论区
+          value: true
+          options:
+            - value: true
+              label:  开启
+            - value: false
+              label:  关闭
         - $formkit: text
           name: link_comment_id
           label:  友链页面-评论区ID

--- a/templates/links.html
+++ b/templates/links.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <th:block xmlns:th="https://www.thymeleaf.org"
           th:insert="~{common/layout :: layout (title = '友链 - ' + ${site.title}, canonical = @{/links}, content = ~{::content}, isPost = false)}"
-          th:with="baseEnableComment = true">
+          th:with="baseEnableComment = ${theme.config.page_config.link_comment_enable}">
     <th:block th:fragment="content"
               th:with="defaultAvatar = ${#strings.defaultString(theme.config.page_config.links_default_avatar, #theme.assets('/img/avatar.svg'))}">
         <div class="card">


### PR DESCRIPTION
看了一下关于友链的改动，原本可以通过设置页面ID来控制是否显示评论区，最新修改后除非站点关闭评论否则无法单独关闭评论了，现追加一项友链评论区开关功能，提供可选项。

**默认开启。**

![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/513366e8-72a8-46c3-98a1-eab817f369c6)
