### PR TITLE
文章支持默认封面

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "author": "nineya",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "release": "eslint **/*.js && gulp release",
-    "push": "eslint **/*.js && gulp push",
+    "release": "eslint src/**/*.js && gulp release",
+    "push": "eslint src/**/*.js && gulp push",
     "zip": "gulp zip",
-    "build": "eslint **/*.js && gulp",
-    "lint": "eslint **/*.js"
+    "build": "eslint src/**/*.js && gulp",
+    "lint": "eslint src/**/*.js"
   },
   "repository": {
     "type": "git",

--- a/settings.yaml
+++ b/settings.yaml
@@ -270,6 +270,11 @@ spec:
           label: 默认文章缩略图
           placeholder: '请输入/选择图片路径'
           help: "如果文章没有指定缩略图，则默认显示当前缩略图。"
+        - $formkit: attachment
+          name: default_cover
+          label: 默认文章封面图
+          placeholder: '请输入/选择图片路径'
+          help: "如果文章没有指定封面图，则默认显示当前封面图。"
         - $formkit: select
           name: top_thumbnail_mode
           label:  置顶文章列表缩略图模式

--- a/templates/archives.html
+++ b/templates/archives.html
@@ -12,9 +12,11 @@
         <div class="timeline-title" th:text="${archive.year}"></div>
         <div class="timeline">
           <th:block th:each="months : ${archive.months}">
-            <article th:each="post : ${months.posts}" class="media">
-              <a th:if="${!#strings.isEmpty(post.spec.cover)}" th:href="${post.status.permalink}" class="media-left">
-                <img class="not-gallery" th:src="${post.spec.cover}" th:alt="${post.spec.title}">
+            <article th:each="post : ${months.posts}" class="media"
+                     th:with="defaultCover = ${#strings.isEmpty(theme.config.post.default_cover) ? '' : (theme.config.post.default_cover + (#strings.contains(theme.config.post.default_cover, '?') ? '&' : '?') + 'tname=' + post.metadata.name)},
+                     postCover = ${#strings.isEmpty(post.spec.cover) ? (#strings.isEmpty(defaultCover) ? '' : defaultCover) : post.spec.cover}">
+              <a th:if="${!#strings.isEmpty(postCover)}" th:href="${post.status.permalink}" class="media-left">
+                <img class="not-gallery" th:src="${postCover}" th:alt="${post.spec.title}">
               </a>
               <div class="media-content">
                 <time th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd')}"></time>

--- a/templates/main/article.html
+++ b/templates/main/article.html
@@ -1,9 +1,10 @@
 <th:block xmlns:th="https://www.thymeleaf.org"
      th:fragment="article (post, type)"
-     th:with="updateInterval = ${T(java.lang.Math).floor((#dates.createNow().getTime()/1000.0 - post.status.lastModifyTime.getEpochSecond())/86400.0).intValue()}">
+     th:with="updateInterval = ${T(java.lang.Math).floor((#dates.createNow().getTime()/1000.0 - post.status.lastModifyTime.getEpochSecond())/86400.0).intValue()},
+     postCover = ${#strings.isEmpty(post.spec.cover) ? (#strings.isEmpty(theme.config.post.default_cover) ? '' : theme.config.post.default_cover) : post.spec.cover}">
 
-    <div th:if="${!#strings.isEmpty(post.spec.cover)}" class="card widget">
-        <div class="cover-image" th:style="'background-image: url(' + ${post.spec.cover} + ')'">
+    <div th:if="${!#strings.isEmpty(postCover)}" class="card widget">
+        <div class="cover-image" th:style="'background-image: url(' + ${postCover} + ')'">
             <div th:if="${type == 'Post' && !#lists.isEmpty(post.categories)}" class="category">
                 <a th:each="cy : ${post.categories}" th:href="${cy.status.permalink}"
                    th:text="${cy.spec.displayName}"></a>&nbsp;
@@ -34,7 +35,7 @@
 
     <div class="card">
         <div class="card-content main">
-            <th:block th:if="${#strings.isEmpty(post.spec.cover)}">
+            <th:block th:if="${#strings.isEmpty(postCover)}">
                 <h1 class="title" th:text="${post.spec.title}"></h1>
                 <div class="meta">
                     <ul class="breadcrumb">


### PR DESCRIPTION
1. 文章支持设置默认封面
2. 归档页面支持默认封面设置
3. 修复 npm i  后，eslint 会报不应该扫描 node_modules 错误。