### PR TITLE
perf：优化调整友链界面关联评论区功能

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -872,11 +872,20 @@ spec:
           label: "友链页面-补充信息"
           placeholder: '请输入补充信息'
           help: '友链页面最低部的补充说明信息，支持 HTML 格式。'
-        - $formkit: text
+        - $formkit: radio
+          name: link_enable_comment
+          label:  友链页面-开启评论区
+          value: false
+          options:
+            - value: true
+              label:  开启
+            - value: false
+              label:  关闭
+        - $formkit: singlePageSelect
           name: link_comment_id
           label:  友链页面-评论区ID
-          placeholder: '请输入 ID'
-          help: '友链页面没有 ID，需要指定一个自定义页面的 ID 用于评论，被指定的文章评论区将作为友链的评论区，放空则友链界面不显示评论区。'
+          placeholder: '请选择一个页面作为友链页面的评论区ID'
+          help: '友链页面没有 ID，需要指定一个自定义页面的 ID 用于评论，被指定的页面评论区将作为友链的评论区，未选择时则友链界面不显示评论区。'
         - $formkit: radio
           name: enable_tags_tag_color
           label:  标签页面-开启标签颜色

--- a/templates/links.html
+++ b/templates/links.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <th:block xmlns:th="https://www.thymeleaf.org"
           th:insert="~{common/layout :: layout (title = '友链 - ' + ${site.title}, canonical = @{/links}, content = ~{::content}, isPost = false)}"
-          th:with="baseEnableComment = ${!#strings.isEmpty(theme.config.page_config.link_comment_id)}">
+          th:with="baseEnableComment = ${!#strings.isEmpty(theme.config.page_config.link_comment_id) && theme.config.page_config.link_enable_comment}">
     <th:block th:fragment="content"
               th:with="defaultAvatar = ${#strings.defaultString(theme.config.page_config.links_default_avatar, #theme.assets('/img/avatar.svg'))}">
         <div class="card">


### PR DESCRIPTION
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/5a2c0012-ef02-435c-9fda-f169fb3be6d2)

- 使用文章选择器选择依附的评论区ID，别面无法使用常规方式获取页面ID而导致的填写错误
- 评论区ID填写错误时
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/96353e8e-2c12-4745-a0a2-dc9e93d9260d)
- 现在将会根据定义的页面标题进行显示
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/72ac49fc-62d3-4eaa-a3bd-3f83b05e6f39)

#80 
