### PR TITLE
perf：优化 友链页面-开启评论区，默认为“开”

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -875,7 +875,7 @@ spec:
         - $formkit: radio
           name: link_enable_comment
           label:  友链页面-开启评论区
-          value: false
+          value: true
           options:
             - value: true
               label:  开启


### PR DESCRIPTION
- **评论区开启条件：开启友链评论区 + 正确选择评论区页面ID；**
- 默认开启友链评论区，针对已开启友链评论区的用户保持开启，若原本未设置评论区ID的用户则评论区仍不会显示；
- 若升级前评论区ID配置正确，升级后会正确识别所选的页面；
- 若升级前已配置评论区ID，且ID不正确，则升级后须重新选择页面，使评论ID正确配置，反之评论审核模块下仍会显示`未知 未知`；
- 若升级前未配置评论区ID，则升级后仍不会显示评论区。