### PR TITLE
perf：优化菜单栏鼠标悬停时显示信息

### DIFF
--- a/templates/common/navbar.html
+++ b/templates/common/navbar.html
@@ -15,7 +15,7 @@
                        class="item"
                        th:href="${menuItem.status.href}"
                        th:target="${menuItem.spec.target?.value}"
-                       th:title="${menuItem.status.displayName}">
+                       th:title="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'desc', '')) ? #annotations.getOrDefault(menuItem, 'desc', '') : menuItem.status.displayName}">
                         <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                            th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                         [[${menuItem.status.displayName}]]
@@ -25,7 +25,7 @@
                             <a class="item"
                                th:href="${#strings.defaultString(menuItem.status.href, 'javascript:')}"
                                th:target="${menuItem.spec.target?.value}"
-                               th:title="${menuItem.status.displayName}">
+                               th:title="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'desc', '')) ? #annotations.getOrDefault(menuItem, 'desc', '') : menuItem.status.displayName}">
                                 <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                                    th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                                 [[${menuItem.status.displayName}]]
@@ -37,7 +37,7 @@
                                 <a class="item"
                                    th:href="${#strings.defaultString(dropdown.status.href, 'javascript:')}"
                                    th:target="${dropdown.spec.target?.value}"
-                                   th:title="${dropdown.status.displayName}">
+                                   th:title="${!#strings.isEmpty(#annotations.getOrDefault(dropdown, 'desc', '')) ? #annotations.getOrDefault(dropdown, 'desc', '') : dropdown.status.displayName}">
                                     <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdown, 'icon', ''))}"
                                        th:class="${'m-icon ' + #annotations.getOrDefault(dropdown, 'icon', '')}"></i>
                                     [[${dropdown.status.displayName}]]
@@ -47,7 +47,7 @@
                                         <a class="item"
                                            th:href="${dropdownChild.status.href}"
                                            th:target="${dropdownChild.spec.target?.value}"
-                                           th:title="${dropdownChild.status.displayName}">
+                                           th:title="${!#strings.isEmpty(#annotations.getOrDefault(dropdownChild, 'desc', '')) ? #annotations.getOrDefault(dropdownChild, 'desc', '') : dropdownChild.status.displayName}">
                                             <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdownChild, 'icon', ''))}"
                                                th:class="${'m-icon ' + #annotations.getOrDefault(dropdownChild, 'icon', '')}"></i>
                                             [[${dropdownChild.status.displayName}]]

--- a/templates/common/navbar.html
+++ b/templates/common/navbar.html
@@ -15,7 +15,7 @@
                        class="item"
                        th:href="${menuItem.status.href}"
                        th:target="${menuItem.spec.target?.value}"
-                       th:title="${#annotations.contains(menuItem, 'desc') ? #annotations.getOrDefault(menuItem, 'desc', '') : menuItem.status.displayName}">
+                       th:title="${#annotations.getOrDefault(menuItem, 'desc',  menuItem.status.displayName)}">
                         <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                            th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                         [[${menuItem.status.displayName}]]
@@ -25,7 +25,7 @@
                             <a class="item"
                                th:href="${#strings.defaultString(menuItem.status.href, 'javascript:')}"
                                th:target="${menuItem.spec.target?.value}"
-                               th:title="${#annotations.contains(menuItem, 'desc') ? #annotations.getOrDefault(menuItem, 'desc', '') : menuItem.status.displayName}">
+                               th:title="${#annotations.getOrDefault(menuItem, 'desc', menuItem.status.displayName)}">
                                 <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                                    th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                                 [[${menuItem.status.displayName}]]
@@ -37,7 +37,7 @@
                                 <a class="item"
                                    th:href="${#strings.defaultString(dropdown.status.href, 'javascript:')}"
                                    th:target="${dropdown.spec.target?.value}"
-                                   th:title="${#annotations.contains(dropdown, 'desc') ? #annotations.getOrDefault(dropdown, 'desc', '') : dropdown.status.displayName}">
+                                   th:title="${#annotations.getOrDefault(dropdown, 'desc', dropdown.status.displayName)}">
                                     <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdown, 'icon', ''))}"
                                        th:class="${'m-icon ' + #annotations.getOrDefault(dropdown, 'icon', '')}"></i>
                                     [[${dropdown.status.displayName}]]
@@ -47,7 +47,7 @@
                                         <a class="item"
                                            th:href="${dropdownChild.status.href}"
                                            th:target="${dropdownChild.spec.target?.value}"
-                                           th:title="${#annotations.contains(dropdownChild, 'desc') ? #annotations.getOrDefault(dropdownChild, 'desc', '') : dropdownChild.status.displayName}">
+                                           th:title="${#annotations.getOrDefault(dropdownChild, 'desc', dropdownChild.status.displayName)}">
                                             <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdownChild, 'icon', ''))}"
                                                th:class="${'m-icon ' + #annotations.getOrDefault(dropdownChild, 'icon', '')}"></i>
                                             [[${dropdownChild.status.displayName}]]

--- a/templates/common/navbar.html
+++ b/templates/common/navbar.html
@@ -15,7 +15,7 @@
                        class="item"
                        th:href="${menuItem.status.href}"
                        th:target="${menuItem.spec.target?.value}"
-                       th:title="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'desc', '')) ? #annotations.getOrDefault(menuItem, 'desc', '') : menuItem.status.displayName}">
+                       th:title="${#annotations.contains(menuItem, 'desc') ? #annotations.getOrDefault(menuItem, 'desc', '') : menuItem.status.displayName}">
                         <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                            th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                         [[${menuItem.status.displayName}]]
@@ -25,7 +25,7 @@
                             <a class="item"
                                th:href="${#strings.defaultString(menuItem.status.href, 'javascript:')}"
                                th:target="${menuItem.spec.target?.value}"
-                               th:title="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'desc', '')) ? #annotations.getOrDefault(menuItem, 'desc', '') : menuItem.status.displayName}">
+                               th:title="${#annotations.contains(menuItem, 'desc') ? #annotations.getOrDefault(menuItem, 'desc', '') : menuItem.status.displayName}">
                                 <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                                    th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                                 [[${menuItem.status.displayName}]]
@@ -37,7 +37,7 @@
                                 <a class="item"
                                    th:href="${#strings.defaultString(dropdown.status.href, 'javascript:')}"
                                    th:target="${dropdown.spec.target?.value}"
-                                   th:title="${!#strings.isEmpty(#annotations.getOrDefault(dropdown, 'desc', '')) ? #annotations.getOrDefault(dropdown, 'desc', '') : dropdown.status.displayName}">
+                                   th:title="${#annotations.contains(dropdown, 'desc') ? #annotations.getOrDefault(dropdown, 'desc', '') : dropdown.status.displayName}">
                                     <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdown, 'icon', ''))}"
                                        th:class="${'m-icon ' + #annotations.getOrDefault(dropdown, 'icon', '')}"></i>
                                     [[${dropdown.status.displayName}]]
@@ -47,7 +47,7 @@
                                         <a class="item"
                                            th:href="${dropdownChild.status.href}"
                                            th:target="${dropdownChild.spec.target?.value}"
-                                           th:title="${!#strings.isEmpty(#annotations.getOrDefault(dropdownChild, 'desc', '')) ? #annotations.getOrDefault(dropdownChild, 'desc', '') : dropdownChild.status.displayName}">
+                                           th:title="${#annotations.contains(dropdownChild, 'desc') ? #annotations.getOrDefault(dropdownChild, 'desc', '') : dropdownChild.status.displayName}">
                                             <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdownChild, 'icon', ''))}"
                                                th:class="${'m-icon ' + #annotations.getOrDefault(dropdownChild, 'icon', '')}"></i>
                                             [[${dropdownChild.status.displayName}]]


### PR DESCRIPTION
### perf：优化菜单栏鼠标悬停时显示信息

- 支持在后台菜单设置中，添加元数据`desc`属性改变鼠标悬停时的显示信息；
- 若未设置`desc`时，鼠标悬停时默认显示菜单名，与原本一致，升级后的用户未做更改前产生影响；
- 若设置`desc`且未输入`value`时，鼠标悬停时将不会显示任何信息；
- 若设置`desc`且输入`value`时，鼠标悬停时将会显示输入的信息；

##### 设置`desc`且未输入`value`时
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/812e0ea9-b847-4662-811d-813652ed27c3)
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/8c913da5-c0ba-4f35-8bfb-f477af0ab055)
##### 设置`desc`且输入`value`时
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/7975ece6-d4f6-4fce-bd9a-240d2d17721d)

**菜单最大支持3级**
