### PR TITLE
 perf：优化瞬间、相册界面标题和浏览器标签页标题跟随瞬间、相册插件的页面标题设置

### DIFF
--- a/templates/moments.html
+++ b/templates/moments.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
 <th:block
-  th:insert="~{common/layout :: layout (title = '瞬间 - ' + ${site.title}, canonical = @{/moments}, content = ~{::content}, isPost = true)}"
+  th:insert="~{common/layout :: layout (title = ${title} + ' - ' + ${site.title}, canonical = @{/moments}, content = ~{::content}, isPost = true)}"
   th:with="isJournals = true, enableShare = ${theme.config.page_config.enable_journals_share}, baseEnableComment = ${theme.config.page_config.enable_journals_comment}"
   xmlns:th="https://www.thymeleaf.org">
   <th:block th:fragment="content">
+    <div class="card card-content friends-hide-stats">
+      <div class="card-tab">
+        <div>[[${#strings.replace(title, ' - ' + site.title, '')}]]</div>
+      </div>
+    </div>
     <div class="card card-content journal" th:each="moment : ${moments.items}">
       <p class="journal-date">
         <i class="ri-send-plane-line"></i>

--- a/templates/photos.html
+++ b/templates/photos.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <th:block xmlns:th="https://www.thymeleaf.org"
-          th:insert="~{common/layout :: layout (title = '我的相册 - ' + ${site.title}, canonical = @{/links}, content = ~{::content}, isPost = false)}"
+          th:insert="~{common/layout :: layout (title = ${title} + ' - ' + ${site.title}, canonical = @{/links}, content = ~{::content}, isPost = false)}"
           th:with="isPhotos = true">
     <th:block th:fragment="content">
         <div class="card card-content photos">
-            <div class="card-tab"><div>我的相册</div></div>
+            <div class="card-tab"><div>[[${#strings.replace(title, ' - ' + site.title, '')}]]</div></div>
             <div class="photos-teams">
                 <a th:class="${#strings.isEmpty(param.group)? 'item active' : 'item'}" th:href="@{/photos}">全部</a>
                 <a th:each="group : ${groups}" th:class="${#strings.equals(param.group, group.metadata.name)? 'item active' : 'item'}" th:href="@{/photos(group=${group.metadata.name})}" th:text="${group.spec.displayName}"></a>


### PR DESCRIPTION
- 优化相册界面标题和浏览器标签页标题跟随相册插件的页面标题设置 
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/747f80ae-5144-48f5-8299-00be4168d041)
- 优化瞬间界面标题和浏览器标签页标题跟随瞬间插件的页面标题设置
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/d3f56c1e-1fa0-4c50-9b7f-5af26d9abae6)