### PR TITLE
fix：限制朋友圈文章描述显示过多导致的样式不正确

### DIFF
--- a/templates/friends.html
+++ b/templates/friends.html
@@ -37,7 +37,7 @@
       </p>
       <div class="friends-content fold">
         <div class="main-content not-toc description">
-          <span th:text="${spec.description}"></span>
+          <span th:text="${#strings.length(spec.description) > 150 ? #strings.substring(spec.description, 0 ,150) : spec.description}"></span>
         </div>
       </div>
       <div class="friends-date">


### PR DESCRIPTION
限制显示150字