### PR TITLE
fix：朋友圈文章最大限制150字符，支持识别html标签

### DIFF
--- a/templates/friends.html
+++ b/templates/friends.html
@@ -37,7 +37,7 @@
       </p>
       <div class="friends-content fold">
         <div class="main-content not-toc description">
-          <span th:text="${spec.description}"></span>
+          <span th:text="${#strings.length(spec.description) > 150 ? #strings.substring(spec.description, 0 ,150) : spec.description}"></span>
         </div>
       </div>
       <div class="friends-date">

--- a/templates/friends.html
+++ b/templates/friends.html
@@ -37,7 +37,7 @@
       </p>
       <div class="friends-content fold">
         <div class="main-content not-toc description">
-          <span th:utext="${#strings.length(spec.description) > 150 ? #strings.substring(spec.description, 0 ,150) : spec.description}"></span>
+          <span th:utext="${#strings.length(spec.description) > 150 ? (#strings.substring(spec.description, 0 ,150) + '...') : spec.description}"></span>
         </div>
       </div>
       <div class="friends-date">

--- a/templates/friends.html
+++ b/templates/friends.html
@@ -37,7 +37,7 @@
       </p>
       <div class="friends-content fold">
         <div class="main-content not-toc description">
-          <span th:text="${#strings.length(spec.description) > 150 ? #strings.substring(spec.description, 0 ,150) : spec.description}"></span>
+          <span th:utext="${#strings.length(spec.description) > 150 ? #strings.substring(spec.description, 0 ,150) : spec.description}"></span>
         </div>
       </div>
       <div class="friends-date">


### PR DESCRIPTION
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/0228dd73-7a3c-4b47-8ae4-873c274412ac)
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/11857188-f4d4-4d86-9486-68f9d342274e)

这样感觉好多了
#96 