### PR TITLE
feat: 新增友链页面支持标题自定义，新增申请友链支持填写RSS订阅地址

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -844,6 +844,11 @@ spec:
     - group: page_config
       label: '页面设置'
       formSchema:
+        - $formkit: text
+          name: links_title
+          label: 友链页面-标题
+          placeholder: '请输入友链页面的标题名称'
+          help: '填写友链页面的标题名称，留空时显示“友链”。'
         - $formkit: attachment
           name: links_thumbnail
           label: 友链页面-封面图
@@ -867,6 +872,11 @@ spec:
           label: '友链页面-交换信息自定义 Logo 链接'
           placeholder: '请输入/选择 Logo 路径'
           help: '用于交换友链的 Logo 链接。'
+        - $formkit: text
+          name: links_rss_address
+          label: 友链页面-RSS订阅地址
+          placeholder: '请输入RSS订阅地址'
+          help: '用于交换友链时添加朋友圈的RSS订阅地址。'
         - $formkit: code
           name: links_info
           label: "友链页面-补充信息"

--- a/templates/links.html
+++ b/templates/links.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <th:block xmlns:th="https://www.thymeleaf.org"
-          th:insert="~{common/layout :: layout (title = '友链 - ' + ${site.title}, canonical = @{/links}, content = ~{::content}, isPost = false)}"
+          th:insert="~{common/layout :: layout (title = ${#strings.defaultString(theme.config.page_config.links_title, '友链')} + ' - ' + ${site.title}, canonical = @{/links}, content = ~{::content}, isPost = false)}"
           th:with="baseEnableComment = ${!#strings.isEmpty(theme.config.page_config.link_comment_id) && theme.config.page_config.link_enable_comment}">
     <th:block th:fragment="content"
               th:with="defaultAvatar = ${#strings.defaultString(theme.config.page_config.links_default_avatar, #theme.assets('/img/avatar.svg'))}">
@@ -8,7 +8,7 @@
             <div th:if="${!#strings.isEmpty(theme.config.page_config.links_thumbnail)}" class="card-image cover-image" th:style="'background-image: url(' + ${theme.config.page_config.links_thumbnail} + ')'">
             </div>
             <div class="card-content main">
-                <h1 class="title" th:text="'友情链接 - ' + ${contributor.displayName} + '的小伙伴们'"></h1>
+                <h1 class="title" th:text="${#strings.defaultString(theme.config.page_config.links_title, '友链')} + ' - ' + ${contributor.displayName} + '的小伙伴们'"></h1>
                 <div class="main-content">
                     <th:block th:each="group : ${groups}">
                         <div th:if="${!#lists.isEmpty(group.links)}" class="links">
@@ -37,9 +37,10 @@
                         申请友链的方法：
                         <ul>
                             <li>名称：[[${site.title}]]</li>
-                            <li>地址：<a th:href="${site.url}" th:text="${site.url}"></a></li>
-                            <li>图标：<a th:href="${bloggerAvatar}" th:text="${bloggerAvatar}"></a></li>
+                            <li>地址：<a th:href="${site.url}" target="_blank" th:text="${site.url}"></a></li>
+                            <li>图标：<a th:href="${bloggerAvatar}" target="_blank" th:text="${bloggerAvatar}"></a></li>
                             <li>描述：[[${contributor.bio}]]</li>
+                            <li>订阅：<a th:href="${theme.config.page_config.links_rss_address}" target="_blank" th:text="${theme.config.page_config.links_rss_address}"></a></li>
                         </ul>
                     </th:block>
                     <div th:if="${!#strings.isEmpty(theme.config.page_config.links_info)}" th:utext="${theme.config.page_config.links_info}"></div>

--- a/templates/links.html
+++ b/templates/links.html
@@ -40,7 +40,7 @@
                             <li>地址：<a th:href="${site.url}" target="_blank" th:text="${site.url}"></a></li>
                             <li>图标：<a th:href="${bloggerAvatar}" target="_blank" th:text="${bloggerAvatar}"></a></li>
                             <li>描述：[[${contributor.bio}]]</li>
-                            <li>订阅：<a th:href="${theme.config.page_config.links_rss_address}" target="_blank" th:text="${theme.config.page_config.links_rss_address}"></a></li>
+                            <li th:if="${!#strings.isEmpty(theme.config.page_config.links_rss_address)}">订阅：<a th:href="${theme.config.page_config.links_rss_address}" target="_blank" th:text="${theme.config.page_config.links_rss_address}"></a></li>
                         </ul>
                     </th:block>
                     <div th:if="${!#strings.isEmpty(theme.config.page_config.links_info)}" th:utext="${theme.config.page_config.links_info}"></div>


### PR DESCRIPTION
### 新增主题设置
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/720ad9b6-020a-4f9a-9f8e-16b7fd9a6625)

### 标题修改
- 允许站长自定义页面标题，可以修改为自己喜欢的名字。

### 增加订阅地址配置
- 方便支持朋友圈或订阅的站长直接获取订阅地址。

#104，预览版V1.3.0.3
