### PR TITLE
feat: 侧边栏-分类 支持树状显示，以及其他bug修复

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -782,7 +782,7 @@ spec:
           name: categories_more
           label:  侧边栏分类-显示”更多”按钮
           value: true
-          help: '超出展示的分类数量后是否显示更多按钮。'
+          help: '侧边栏分类是否显示更多按钮。'
           options:
             - value: true
               label:  显示
@@ -790,14 +790,14 @@ spec:
               label:  不显示
         - $formkit: number
           name: categories_num
-          label:  侧边栏分类-展示分类数量
+          label:  侧边栏分类-各级别展示分类的最大数量
           placeholder: 请输入数量数值
           value: 10
         - $formkit: radio
           name: tags_more
           label:  侧边栏标签-显示”更多”按钮
           value: true
-          help: '超出展示的标签数量后是否显示更多按钮。'
+          help: '侧边栏标签是否显示更多按钮。'
           options:
             - value: true
               label:  显示
@@ -821,7 +821,7 @@ spec:
           name: tagcloud_more
           label:  侧边栏标签云-显示”更多”按钮
           value: true
-          help: '超出展示的标签数量后是否显示更多按钮。'
+          help: '侧边栏标签云是否显示更多按钮。'
           options:
             - value: true
               label:  显示

--- a/templates/widget/categories.html
+++ b/templates/widget/categories.html
@@ -2,22 +2,27 @@
      th:fragment="widget (hide)"
      th:class="'card widget ' + ${hide}"
      th:with="num = ${#strings.isEmpty(theme.config.sidebar.categories_num)? 10 : T(java.lang.Integer).parseInt(theme.config.sidebar.categories_num)},
-     categories = ${categoryFinder.list(1,num)},
+     categories = ${categoryFinder.listAsTree()},
      isEmpty = ${#lists.isEmpty(categories)}">
     <div class="card-title">
         <i class="ri-apps-line card-title-label"></i><span>分类</span>
-        <a th:if="${categories.hasNext}" class="card-more" th:href="@{/categories}">更多<i
+        <a th:if="${#lists.size(categories) > num && theme.config.sidebar.categories_more}" class="card-more" th:href="@{/categories}">更多<i
                 class="ri-arrow-right-double-line"></i></a>
     </div>
     <div th:if="${isEmpty}" class="card-empty">暂无分类</div>
     <div th:unless="${isEmpty}" class="card-content">
         <ul class="menu-list">
-            <li th:each="category : ${categories}">
-                <a class="level is-marginless" th:href="${category.status.permalink}">
-                    <span class="level-item" th:text="${category.spec.displayName}"></span>
-                    <span class="level-item tag" th:text="${category.status.postCount}"></span>
-                </a>
-            </li>
+            <th:block th:fragment="categories (categories, noLimit)">
+                <li th:each="category,itemIndex : ${categories}" th:unless="${itemIndex.index >= num && noLimit == null}">
+                    <a class="level is-marginless" th:href="${category.status.permalink}">
+                        <span class="level-item" th:text="${category.spec.displayName}"></span>
+                        <span class="level-item tag" th:text="${category.status.postCount}"></span>
+                    </a>
+                    <ul th:if="${!#lists.isEmpty(category.children)}">
+                        <th:block th:replace="~{:: categories (${category.children}, true)}"/>
+                    </ul>
+                </li>
+            </th:block>
         </ul>
     </div>
 </div>

--- a/templates/widget/categories.html
+++ b/templates/widget/categories.html
@@ -6,20 +6,20 @@
      isEmpty = ${#lists.isEmpty(categories)}">
     <div class="card-title">
         <i class="ri-apps-line card-title-label"></i><span>分类</span>
-        <a th:if="${#lists.size(categories) > num && theme.config.sidebar.categories_more}" class="card-more" th:href="@{/categories}">更多<i
+        <a th:if="${theme.config.sidebar.categories_more}" class="card-more" th:href="@{/categories}">更多<i
                 class="ri-arrow-right-double-line"></i></a>
     </div>
     <div th:if="${isEmpty}" class="card-empty">暂无分类</div>
     <div th:unless="${isEmpty}" class="card-content">
         <ul class="menu-list">
-            <th:block th:fragment="categories (categories, noLimit)">
-                <li th:each="category,itemIndex : ${categories}" th:unless="${itemIndex.index >= num && noLimit == null}">
+            <th:block th:fragment="categories (categories)">
+                <li th:each="category,itemIndex : ${categories}" th:unless="${itemIndex.index >= num}">
                     <a class="level is-marginless" th:href="${category.status.permalink}">
                         <span class="level-item" th:text="${category.spec.displayName}"></span>
                         <span class="level-item tag" th:text="${category.status.postCount}"></span>
                     </a>
                     <ul th:if="${!#lists.isEmpty(category.children)}">
-                        <th:block th:replace="~{:: categories (${category.children}, true)}"/>
+                        <th:block th:replace="~{:: categories (${category.children})}"/>
                     </ul>
                 </li>
             </th:block>

--- a/templates/widget/tagcloud.html
+++ b/templates/widget/tagcloud.html
@@ -8,7 +8,7 @@
 
     <div class="card-title">
         <i class="ri-cloud-line card-title-label"></i><span>标签云</span>
-        <a th:if="${tags.hasNext}" class="card-more" th:href="@{/tags}">更多<i class="ri-arrow-right-double-line"></i></a>
+        <a th:if="${tags.hasNext && theme.config.sidebar.tagcloud_more}" class="card-more" th:href="@{/tags}">更多<i class="ri-arrow-right-double-line"></i></a>
     </div>
     <div th:if="${isEmpty}" class="card-empty">暂无标签</div>
     <div th:unless="${isEmpty}" class="card-content">

--- a/templates/widget/tagcloud.html
+++ b/templates/widget/tagcloud.html
@@ -8,7 +8,7 @@
 
     <div class="card-title">
         <i class="ri-cloud-line card-title-label"></i><span>标签云</span>
-        <a th:if="${tags.hasNext && theme.config.sidebar.tagcloud_more}" class="card-more" th:href="@{/tags}">更多<i class="ri-arrow-right-double-line"></i></a>
+        <a th:if="${theme.config.sidebar.tagcloud_more}" class="card-more" th:href="@{/tags}">更多<i class="ri-arrow-right-double-line"></i></a>
     </div>
     <div th:if="${isEmpty}" class="card-empty">暂无标签</div>
     <div th:unless="${isEmpty}" class="card-content">

--- a/templates/widget/tags.html
+++ b/templates/widget/tags.html
@@ -7,7 +7,7 @@
      enableTagsColor = ${theme.config.sidebar.enable_tag_color}">
     <div class="card-title">
         <i class="ri-price-tag-3-line card-title-label"></i><span>标签</span>
-        <a th:if="${tags.hasNext && theme.config.sidebar.tags_more}" class="card-more" th:href="@{/tags}">更多<i class="ri-arrow-right-double-line"></i></a>
+        <a th:if="${theme.config.sidebar.tags_more}" class="card-more" th:href="@{/tags}">更多<i class="ri-arrow-right-double-line"></i></a>
     </div>
     <div th:if="${isEmpty}" class="card-empty">暂无标签</div>
     <div th:unless="${isEmpty}" class="card-content">

--- a/templates/widget/tags.html
+++ b/templates/widget/tags.html
@@ -7,7 +7,7 @@
      enableTagsColor = ${theme.config.sidebar.enable_tag_color}">
     <div class="card-title">
         <i class="ri-price-tag-3-line card-title-label"></i><span>标签</span>
-        <a th:if="${tags.hasNext}" class="card-more" th:href="@{/tags}">更多<i class="ri-arrow-right-double-line"></i></a>
+        <a th:if="${tags.hasNext && theme.config.sidebar.tags_more}" class="card-more" th:href="@{/tags}">更多<i class="ri-arrow-right-double-line"></i></a>
     </div>
     <div th:if="${isEmpty}" class="card-empty">暂无标签</div>
     <div th:unless="${isEmpty}" class="card-content">


### PR DESCRIPTION
## 按照方案一修改
### 优化
- **侧边栏-分类**支持树状显示；
- **侧边栏-分类**按照后台顺序显示；
- **侧边栏-分类**的**各级分类受主题设置分类数量限制**；
### 修复
- 分类更多显示配置项未生效的问题，**改为直接控制是否显示更多**；
- 标签更多显示配置项未生效的问题，**改为直接控制是否显示更多**；
- 标签云更多显示配置项未生效的问题，**改为直接控制是否显示更多**。


## 主题设置描述变更
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/5a601edf-1dec-49df-8f7e-42661bf02642)


#107 
#108 