### PR TITLE
perf: 优化菜单栏配置元数据

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -147,3 +147,23 @@ spec:
           label:  关闭
         - value: ""
           label:  跟随默认配置
+
+---
+
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: ""
+    kind: MenuItem
+  formSchema:
+    - $formkit: "text"
+      name: "icon"
+      label: "图标"
+      placeholder: '请输入菜单图标，支持Remix V3.5.0'
+    - $formkit: "text"
+      name: "desc"
+      label: "描述"
+      placeholder: '请输入鼠标悬停时描述内容，默认为菜单名'

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -282,16 +282,22 @@ const commonContext = {
   /* 离屏提示 */
   offscreenTip() {
     if (Utils.isMobile() || (!DreamConfig.document_hidden_title && !DreamConfig.document_visible_title)) return
-    const originTitle = document.title
+    // const originTitle = document.title
+    let originTitle = document.title
     let timer = null
     document.addEventListener('visibilitychange', function () {
       if (document.hidden) {
+        if(!DreamConfig.document_visible_title || document.title !== DreamConfig.document_visible_title) {
+          originTitle = document.title
+        }
         DreamConfig.document_hidden_title && (document.title = DreamConfig.document_hidden_title)
         clearTimeout(timer)
       } else {
         document.title = DreamConfig.document_visible_title || originTitle
         DreamConfig.document_visible_title && (timer = setTimeout(function () {
-          document.title = originTitle
+          if(document.title === DreamConfig.document_visible_title){
+            document.title = originTitle
+          }
         }, 2000))
       }
     })

--- a/templates/common/footer.html
+++ b/templates/common/footer.html
@@ -16,7 +16,7 @@
                   th:if="${!#strings.isEmpty(theme.config.basic_info.record_number)}"
                   href="http://beian.miit.gov.cn/publish/query/indexFirst.action" target="_blank" rel="noopener noreferrer nofollow"
                   th:text="${theme.config.basic_info.record_number}"></a><span class="footer-truncation">Powered by <a class="powered" href="https://halo.run/" target="_blank">Halo</a> & <a class="powered" href="https://github.com/nineya/halo-theme-dream2.0" target="_blank">Dream</a></span></p>
-              <p class="icon-spot" th:if="${!#strings.isEmpty(theme.config.basic_info.website_time) || theme.config.enhance.enable_busuanzi}">
+              <p class="icon-spot" th:if="${!#strings.isEmpty(theme.config.basic_info.website_time) || theme.config.enhance.enable_busuanzi == true}">
                 <span th:if="${!#strings.isEmpty(theme.config.basic_info.website_time)}" id="websiteDate">建站<span class="stand">00</span>天<span class="stand">0</span>时<span class="stand">0</span>分<span class="stand">0</span>秒</span>
                 <span th:if="${theme.config.enhance.enable_busuanzi == true}" class="icon-spot footer-truncation">
                             <span id="busuanzi_container_site_uv" style="display: none">

--- a/templates/common/navbar.html
+++ b/templates/common/navbar.html
@@ -15,7 +15,8 @@
                        class="item"
                        th:href="${menuItem.status.href}"
                        th:target="${menuItem.spec.target?.value}"
-                       th:title="${#annotations.getOrDefault(menuItem, 'desc',  menuItem.status.displayName)}">
+                       th:with="desc = ${#annotations.getOrDefault(menuItem, 'desc', menuItem.status.displayName)}"
+                       th:title="${#strings.isEmpty(desc) ? menuItem.status.displayName : desc}">
                         <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                            th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                         [[${menuItem.status.displayName}]]
@@ -25,7 +26,8 @@
                             <a class="item"
                                th:href="${#strings.defaultString(menuItem.status.href, 'javascript:')}"
                                th:target="${menuItem.spec.target?.value}"
-                               th:title="${#annotations.getOrDefault(menuItem, 'desc', menuItem.status.displayName)}">
+                               th:with="desc = ${#annotations.getOrDefault(menuItem, 'desc', menuItem.status.displayName)}"
+                               th:title="${#strings.isEmpty(desc) ? menuItem.status.displayName : desc}">
                                 <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                                    th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                                 [[${menuItem.status.displayName}]]
@@ -37,7 +39,8 @@
                                 <a class="item"
                                    th:href="${#strings.defaultString(dropdown.status.href, 'javascript:')}"
                                    th:target="${dropdown.spec.target?.value}"
-                                   th:title="${#annotations.getOrDefault(dropdown, 'desc', dropdown.status.displayName)}">
+                                   th:with="desc = ${#annotations.getOrDefault(dropdown, 'desc', dropdown.status.displayName)}"
+                                   th:title="${#strings.isEmpty(desc) ? dropdown.status.displayName : desc}">
                                     <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdown, 'icon', ''))}"
                                        th:class="${'m-icon ' + #annotations.getOrDefault(dropdown, 'icon', '')}"></i>
                                     [[${dropdown.status.displayName}]]
@@ -47,7 +50,8 @@
                                         <a class="item"
                                            th:href="${dropdownChild.status.href}"
                                            th:target="${dropdownChild.spec.target?.value}"
-                                           th:title="${#annotations.getOrDefault(dropdownChild, 'desc', dropdownChild.status.displayName)}">
+                                           th:with="desc = ${#annotations.getOrDefault(dropdownChild, 'desc', dropdownChild.status.displayName)}"
+                                           th:title="${#strings.isEmpty(desc) ? dropdownChild.status.displayName : desc}">
                                             <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdownChild, 'icon', ''))}"
                                                th:class="${'m-icon ' + #annotations.getOrDefault(dropdownChild, 'icon', '')}"></i>
                                             [[${dropdownChild.status.displayName}]]


### PR DESCRIPTION
### 现在支持直接配置，无需手动输入元数据KEY
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/4cc48d17-7f24-4b43-a3af-79413349ab40)
### 调整菜单描述元数据显示方式，元数据为空时显示菜单名
