### PR TITLE
fix(theme): 设置为跟随系统时，每个页面都会重新刷新为系统主题

### DIFF
--- a/templates/common/config.html
+++ b/templates/common/config.html
@@ -97,7 +97,18 @@
     /** 配置主题模式 */
     DreamConfig["default_theme"] = '[(${theme.config.basic_style.default_theme})]';
     (function(){
-      let isNight = DreamConfig.default_theme === 'system'? matchMedia('(prefers-color-scheme: dark)').matches : localStorage.getItem('night') || DreamConfig.default_theme === 'night';
+      const hasNightInLocal = () => localStorage.getItem('night') !== null;
+      const getNightInConfig = () => {
+        if (DreamConfig.default_theme === 'night') {
+          return true;
+        }
+        if (DreamConfig.default_theme === 'system') {
+          return  matchMedia('(prefers-color-scheme: dark)').matches;
+        }
+        return false;
+      }
+      
+      let isNight = hasNightInLocal() ? localStorage.getItem('night') : getNightInConfig();
       if (isNight.toString() === 'true') {
         localStorage.setItem('night', 'true');
         document.documentElement.classList.add('night');


### PR DESCRIPTION
原逻辑，会导致： 在浏览器页面主动修改了主题后，跳转到其他页面有会跟随系统主题。

跟随系统主题的逻辑应该是：

1. 用户没有修改过主题，则主题跟随系统（如果是dark模式，则设置为dark）
2. 如果用户在页面上点击了 `toggle`，localStorage中的`nigth`是有值的，此时应该以用户设置的值为依据，而非每次都跟随系统。