### PR TITLE
fix：修复离屏提示在pjax下出现离屏回来后标题与原标题不一致的问题

### DIFF
--- a/src/js/common.js
+++ b/src/js/common.js
@@ -282,16 +282,22 @@ const commonContext = {
   /* 离屏提示 */
   offscreenTip() {
     if (Utils.isMobile() || (!DreamConfig.document_hidden_title && !DreamConfig.document_visible_title)) return
-    const originTitle = document.title
+    // const originTitle = document.title
+    let originTitle = document.title
     let timer = null
     document.addEventListener('visibilitychange', function () {
       if (document.hidden) {
+        if(!DreamConfig.document_visible_title || document.title !== DreamConfig.document_visible_title) {
+          originTitle = document.title
+        }
         DreamConfig.document_hidden_title && (document.title = DreamConfig.document_hidden_title)
         clearTimeout(timer)
       } else {
         document.title = DreamConfig.document_visible_title || originTitle
         DreamConfig.document_visible_title && (timer = setTimeout(function () {
-          document.title = originTitle
+          if(document.title === DreamConfig.document_visible_title){
+            document.title = originTitle
+          }
         }, 2000))
       }
     })


### PR DESCRIPTION
启用pjax时切换页面后离屏回来标题栏将会显示正确标题