### PR TITLE
perf：优化菜单栏图标及描述配置

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -147,3 +147,23 @@ spec:
           label:  关闭
         - value: ""
           label:  跟随默认配置
+
+---
+
+apiVersion: v1alpha1
+kind: AnnotationSetting
+metadata:
+  generateName: annotation-setting-
+spec:
+  targetRef:
+    group: ""
+    kind: MenuItem
+  formSchema:
+    - $formkit: "text"
+      name: "icon"
+      label: "图标"
+      placeholder: '请输入菜单图标，支持RemixIcon V3.5.0'
+    - $formkit: "text"
+      name: "desc"
+      label: "描述"
+      placeholder: '请输入鼠标悬停时描述内容，默认为菜单名'

--- a/templates/common/navbar.html
+++ b/templates/common/navbar.html
@@ -15,7 +15,8 @@
                        class="item"
                        th:href="${menuItem.status.href}"
                        th:target="${menuItem.spec.target?.value}"
-                       th:title="${#annotations.getOrDefault(menuItem, 'desc',  menuItem.status.displayName)}">
+                       th:with="desc = ${#annotations.getOrDefault(menuItem, 'desc', menuItem.status.displayName)}"
+                       th:title="${#strings.isEmpty(desc) ? menuItem.status.displayName : desc}">
                         <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                            th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                         [[${menuItem.status.displayName}]]
@@ -25,7 +26,8 @@
                             <a class="item"
                                th:href="${#strings.defaultString(menuItem.status.href, 'javascript:')}"
                                th:target="${menuItem.spec.target?.value}"
-                               th:title="${#annotations.getOrDefault(menuItem, 'desc', menuItem.status.displayName)}">
+                               th:with="desc = ${#annotations.getOrDefault(menuItem, 'desc', menuItem.status.displayName)}"
+                               th:title="${#strings.isEmpty(desc) ? menuItem.status.displayName : desc}">
                                 <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(menuItem, 'icon', ''))}"
                                    th:class="${'m-icon ' + #annotations.getOrDefault(menuItem, 'icon', '')}"></i>
                                 [[${menuItem.status.displayName}]]
@@ -37,7 +39,8 @@
                                 <a class="item"
                                    th:href="${#strings.defaultString(dropdown.status.href, 'javascript:')}"
                                    th:target="${dropdown.spec.target?.value}"
-                                   th:title="${#annotations.getOrDefault(dropdown, 'desc', dropdown.status.displayName)}">
+                                   th:with="desc = ${#annotations.getOrDefault(dropdown, 'desc', dropdown.status.displayName)}"
+                                   th:title="${#strings.isEmpty(desc) ? dropdown.status.displayName : desc}">
                                     <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdown, 'icon', ''))}"
                                        th:class="${'m-icon ' + #annotations.getOrDefault(dropdown, 'icon', '')}"></i>
                                     [[${dropdown.status.displayName}]]
@@ -47,7 +50,8 @@
                                         <a class="item"
                                            th:href="${dropdownChild.status.href}"
                                            th:target="${dropdownChild.spec.target?.value}"
-                                           th:title="${#annotations.getOrDefault(dropdownChild, 'desc', dropdownChild.status.displayName)}">
+                                           th:with="desc = ${#annotations.getOrDefault(dropdownChild, 'desc', dropdownChild.status.displayName)}"
+                                           th:title="${#strings.isEmpty(desc) ? dropdownChild.status.displayName : desc}">
                                             <i th:if="${!#strings.isEmpty(#annotations.getOrDefault(dropdownChild, 'icon', ''))}"
                                                th:class="${'m-icon ' + #annotations.getOrDefault(dropdownChild, 'icon', '')}"></i>
                                             [[${dropdownChild.status.displayName}]]


### PR DESCRIPTION
### perf：优化菜单栏图标及描述配置

- 现在配置菜单栏时将直接显示图标和描述的配置项，无须手动输入相关的元数据key