### PR TITLE
fix：修复图库在某个分组下点击页码跳页时回到全部分组的问题

### DIFF
--- a/templates/main/pagination.html
+++ b/templates/main/pagination.html
@@ -1,7 +1,9 @@
 <div xmlns:th="https://www.thymeleaf.org" xmlns:tj="http://www.w3.org/1999/html"
      th:fragment="pagination (data, path)"
      th:if="${data.totalPages > 1}"
-     class="card card-transparent">
+     class="card card-transparent"
+     th:with="urlParamStr = ${#strings.substringAfter(data.prevUrl,'?')},
+              urlParams = ${urlParamStr == null ? '' : ('?' + urlParamStr)}">
   <nav class="pagination" role="navigation" aria-label="pagination">
     <a th:href="${data.prevUrl}"
        th:class="'pagination-previous' + ${data.hasPrevious()?'':' is-invisible is-hidden-mobile'}">上一页</a>
@@ -13,24 +15,24 @@
         <li th:each="index : ${#numbers.sequence(1, data.totalPages)}">
           <a
             th:class="'pagination-link' + ${data.page == index ? ' is-current': ''}"
-            th:href="@{${path+'/page/'}  + ${index}}" th:text="${index}"></a>
+            th:href="@{${path+'/page/'} + ${index} + ${urlParams}}" th:text="${index}"></a>
         </li>
       </th:block>
       <th:block th:unless="${data.totalPages <= 9}"
       th:with="start = ${(data.page > 5) ? data.page - 2 : 1},
                end = ${start + ((data.page > 5) ? ((data.page < data.totalPages - 4) ? 4 : 6) :  ((data.page < data.totalPages - 4) ? 6 : 8))}">
         <th:block th:if="${data.page > 5}">
-          <li><a class="pagination-link" th:href="@{${path+'/page/1'}}" th:text="1"></a></li>
+          <li><a class="pagination-link" th:href="@{${path+'/page/1' + urlParams}}" th:text="1"></a></li>
           <li><span class="pagination-ellipsis">…</span></li>
         </th:block>
 
         <li th:each="index : ${#numbers.sequence((end > data.totalPages) ? start - end + data.totalPages : start, (end > data.totalPages) ? data.totalPages : end)}"><a
           th:class="'pagination-link' + ${data.page == index ? ' is-current': ''}"
-          th:href="@{${path+'/page/'}  + ${index}}" th:text="${index}"></a></li>
+          th:href="@{${path+'/page/'}  + ${index} + ${urlParams}}" th:text="${index}"></a></li>
 
         <th:block th:if="${data.page < data.totalPages - 4}">
           <li><span class="pagination-ellipsis">…</span></li>
-          <li><a class="pagination-link" th:href="@{${path+'/page/'} + ${data.totalPages}}" th:text="${data.totalPages}"></a></li>
+          <li><a class="pagination-link" th:href="@{${path+'/page/'} + ${data.totalPages} + ${urlParams}}" th:text="${data.totalPages}"></a></li>
         </th:block>
       </th:block>
     </ul>


### PR DESCRIPTION
此bug目前仅在图库发生，由页码的请求路径未携带请求参数引发
`/photos?group=photo-group-BSHRD`
实际请求路径抛弃了`?group=photo-group-BSHRD`