### PR TITLE
perf: 优化侧边栏最近评论显示邮箱头像

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -59,12 +59,6 @@ spec:
           name: cloud_by_url
           label: '云服务提供商 URL'
           placeholder: '请输入链接地址'
-        - $formkit: text
-          label: 头像服务镜像地址
-          help: '用于替换头像服务镜像地址，无须输入结尾的"/"。'
-          name: providerMirror
-          value: "https://cravatar.cn"
-          validation: required
     - group: basic_style
       label: '基础样式'
       formSchema:
@@ -801,6 +795,12 @@ spec:
           label:  侧边栏最近评论-展示评论数量
           placeholder: 请输入数量数值
           value: 5
+        - $formkit: text
+          label: 侧边栏最近评论-邮箱头像服务地址
+          help: '邮箱头像服务地址，支持参考文档自定义部分参数，其中“{hash}”表示邮箱Hash值。'
+          name: providerMirror
+          value: "https://cravatar.cn/avatar/{hash}"
+          validation: required
         - $formkit: radio
           name: categories_more
           label:  侧边栏分类-显示”更多”按钮

--- a/settings.yaml
+++ b/settings.yaml
@@ -59,6 +59,12 @@ spec:
           name: cloud_by_url
           label: '云服务提供商 URL'
           placeholder: '请输入链接地址'
+        - $formkit: text
+          label: 头像服务镜像地址
+          help: '用于替换头像服务镜像地址，无须输入结尾的"/"。'
+          name: providerMirror
+          value: "https://cravatar.cn"
+          validation: required
     - group: basic_style
       label: '基础样式'
       formSchema:

--- a/templates/widget/recent_comments.html
+++ b/templates/widget/recent_comments.html
@@ -11,7 +11,7 @@
             <li class="item" th:each="comment : ${comments}">
                 <div class="user"
                      th:with="
-                     emailHash = ${comment.spec.owner.annotations['email-hash']},
+                     emailHash = ${comment.spec.owner.annotations != null ? comment.spec.owner.annotations['email-hash'] : ''},
                      userA = ${comment.owner.avatar},
                      img = ${#strings.isEmpty(userA) && !#strings.isEmpty(emailHash) ? theme.config.basic_info.providerMirror+'/avatar/'+emailHash : userA}">
                     <img width="35" height="35" th:unless="${#strings.isEmpty(img)}" class="avatar" th:src="${img}"

--- a/templates/widget/recent_comments.html
+++ b/templates/widget/recent_comments.html
@@ -9,10 +9,16 @@
     <div th:unless="${isEmpty}" class="card-content">
         <ul class="widget-comment">
             <li class="item" th:each="comment : ${comments}">
-                <div class="user">
-                    <img width="35" height="35" th:unless="${#strings.isEmpty(comment.owner.avatar)}" class="avatar" th:src="${comment.owner.avatar}"
+                <div class="user"
+                     th:with="
+                     emailHash = ${comment.spec.owner.annotations['email-hash']},
+                     userA = ${comment.owner.avatar},
+                     img = ${#strings.isEmpty(userA) && !#strings.isEmpty(emailHash) ? theme.config.basic_info.providerMirror+'/avatar/'+emailHash : userA}">
+                    <img width="35" height="35" th:unless="${#strings.isEmpty(img)}" class="avatar" th:src="${img}"
                          th:alt="${comment.owner.displayName}">
-                    <div th:if="${#strings.isEmpty(comment.owner.avatar)}" class="no-avatar">
+                    <div th:if="${#strings.isEmpty(img)}" class="no-avatar">
+                        <span class="avatar-info">[[${#strings.substring(comment.owner.displayName, 0, 1)}]]</span>
+                    </div>
                         <span class="avatar-info">[[${#strings.substring(comment.owner.displayName, 0, 1)}]]</span>
                     </div>
                     <div class="info">

--- a/templates/widget/recent_comments.html
+++ b/templates/widget/recent_comments.html
@@ -13,7 +13,7 @@
                      th:with="
                      emailHash = ${comment.spec.owner.annotations != null ? comment.spec.owner.annotations['email-hash'] : ''},
                      userA = ${comment.owner.avatar},
-                     img = ${#strings.isEmpty(userA) && !#strings.isEmpty(emailHash) ? theme.config.basic_info.providerMirror+'/avatar/'+emailHash : userA}">
+                     img = ${#strings.isEmpty(userA) && !#strings.isEmpty(emailHash) ? #strings.replace(theme.config.sidebar.providerMirror, '{hash}', emailHash) : userA}">
                     <img width="35" height="35" th:unless="${#strings.isEmpty(img)}" class="avatar" th:src="${img}"
                          th:alt="${comment.owner.displayName}">
                     <div th:if="${#strings.isEmpty(img)}" class="no-avatar">


### PR DESCRIPTION
### 前置要求：`Halo ≥ 2.15` ，版本不满足时显示方式与原先相同
- 在`侧边栏配置`中新增配置`侧边栏最近评论-邮箱头像服务地址`，**因为halo字段中未返回镜像地址，所以需要主题添加这个设置**；
  - 默认值为：`https://cravatar.cn/avatar/{hash}`，支持配置其他参数，如：`https://cravatar.cn/avatar/{hash}?d=monsterid`默认头像显示为怪物
  
![image](https://github.com/nineya/halo-theme-dream2.0/assets/23021469/6784e818-7c6e-4fc8-aa14-83992b250f91)

- 侧边栏邮箱头像显示机制：
  - 评论用户存在头像则显示头像；
  - 不存在头像时显示邮箱头像；
  - 邮箱头像不存在时显示用户名首字符头像。

### 参考资料
halo-dev/halo#5642
halo-dev/plugin-comment-widget#111

#118 

