### PR TITLE
perf：优化分类、标签、标签云下文章数量显示异常

### DIFF
--- a/templates/categories.html
+++ b/templates/categories.html
@@ -21,7 +21,7 @@
     <li th:each="category : ${categories}">
       <a class="level is-marginless" th:href="${category.status.permalink}">
         <span class="level-item" th:text="${category.spec.displayName}"></span>
-        <span class="level-item tag" th:text="${category.status.postCount}"></span>
+        <span class="level-item tag" th:text="${category.status.postCount == null ? 0 : category.status.postCount}"></span>
       </a>
       <ul th:if="${!#lists.isEmpty(category.children)}">
         <th:block th:replace="~{:: categories (${category.children})}"/>

--- a/templates/tags.html
+++ b/templates/tags.html
@@ -16,7 +16,7 @@
           <a th:each="tag : ${tags}" class="tags" th:href="${tag.status.permalink}">
           <span class="tag" th:text="${tag.spec.displayName}"
                 th:style="${(enableTagsColor && tag.spec.color != '#ffffff')? 'color: ' + tag.spec.color +'; background: ' + tag.spec.color +'20' : ''}"></span>
-            <span class="tag is-grey" th:text="${tag.postCount}"
+            <span class="tag is-grey" th:text="${tag.postCount != null ? tag.postCount : 0}"
                   th:style="${(enableTagsColor && tag.spec.color != '#ffffff')? 'background: ' + tag.spec.color +'CC' : ''}"></span>
           </a>
         </div>

--- a/templates/widget/categories.html
+++ b/templates/widget/categories.html
@@ -1,6 +1,6 @@
 <div xmlns:th="https://www.thymeleaf.org"
      th:fragment="widget (sidebar)"
-     th:class="'card widget ' + ${sidebar.hide}">
+     th:class="'card widget ' + ${sidebar.hide}"
      th:with="num = ${#strings.isEmpty(theme.config.sidebar.categories_num)? 10 : T(java.lang.Integer).parseInt(theme.config.sidebar.categories_num)},
      categories = ${categoryFinder.list(1,num)},
      isEmpty = ${#lists.isEmpty(categories)}">

--- a/templates/widget/tagcloud.html
+++ b/templates/widget/tagcloud.html
@@ -16,7 +16,7 @@
           th:each="tag : ${tags}"
           th:href="@{${tag.status.permalink}}"
           th:text="${tag.spec.displayName}"
-          th:with="size = ${#strings.length(tag.spec.displayName) + #strings.length(tag.spec.slug) + tag.postCount}"
+          th:with="size = ${#strings.length(tag.spec.displayName) + #strings.length(tag.spec.slug) + (tag.postCount != null ? tag.postCount : 0)}"
           th:style="'font-size: ' + ${size < 14 ? 14 : size > 32 ? 32 : size} + 'px;' + ${(enableTagsColor && tag.spec.color != '#ffffff')? 'color: ' + tag.spec.color +';' : ''}"></a>
     </div>
 </div>


### PR DESCRIPTION
针对高版本Halo，返回的文章数量为`null`而不是`0`做的优化