### PR TITLE
fix:  修复变量命名疏漏，优化代码逻辑

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
           </th:block>
         </div>
       </div>
-      <div th:if="${moduleSize > 2}" class="'model model-attach model-attach-' + ${moduleSize - 2}">
+      <div th:if="${moduleSize > 2}" th:class="'model model-attach model-attach-' + ${moduleSize - 2}">
         <th:block th:each="index : ${#numbers.sequence(2, 5)}">
           <th:block th:if="${index < moduleSize}">
             <th:block th:replace="~{::buildModule (${theme.config.basic_style.module_options.get(index)})}"/>

--- a/templates/main/article_list.html
+++ b/templates/main/article_list.html
@@ -1,162 +1,172 @@
-<th:block xmlns:th="https://www.thymeleaf.org"
-          th:fragment="articleList (posts)">
-  <th:block th:each="post : ${posts}"
-            th:with="thumbnail = ${#strings.isEmpty(post.spec.cover) ? #strings.isEmpty(theme.config.post.default_thumbnail) ? '' : theme.config.post.default_thumbnail + (#strings.contains(theme.config.post.default_thumbnail, '?') ? '&' : '?') + 'id=' + post.metadata.name : post.spec.cover},
-            thumbnail_mode = ${(theme.config.post.top_thumbnail_mode == 'grid' || (!post.spec.pinned && theme.config.post.thumbnail_mode == 'grid'))? 'grid' : !#strings.isEmpty(post.metadata.annotations.get('thumbnail_mode'))? post.metadata.annotations.get('thumbnail_mode') : post.spec.pinned ? theme.config.post.top_thumbnail_mode : theme.config.post.thumbnail_mode}">
-    <div th:if="${!#strings.isEmpty(thumbnail) && thumbnail_mode == 'back'}" class="card widget card-cover">
-      <a th:href="${post.status.permalink}">
-        <div class="cover-image" th:style="'background-image: url(' + ${thumbnail} + ')'"></div>
-        <div class="details">
-          <h2 class="title"><span class="top" th:if="${post.spec.pinned}">置顶</span>[[${post.spec.title}]]</h2>
-          <ul class="breadcrumb">
-            <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
-            <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
-            <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i class="ri-question-answer-line"></i>[[${post.stats.comment}]]
-            </li>
-            <li><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]</li>
-            <li
-              th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
-              th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
-            </li>
-          </ul>
-        </div>
-      </a>
-      <div th:if="${!#lists.isEmpty(post.categories)}" class="category">
-        <a th:each="cy : ${post.categories}" th:href="${cy.status.permalink}" th:text="${cy.spec.displayName}"></a>&nbsp;
-      </div>
-    </div>
+<th:block xmlns:th="https://www.thymeleaf.org" th:fragment="articleList (posts)">
+          
+    <th:block th:each="post : ${posts}" 
+              th:with="thumbnail = ${!#strings.isEmpty(post.spec.cover) ? post.spec.cover : (#strings.isEmpty(theme.config.post.default_thumbnail) ? '' : theme.config.post.default_thumbnail + (#strings.contains(theme.config.post.default_thumbnail, '?') ? '&' : '?') + 'id=' + post.metadata.name)}, 
+                       thumbnail_mode = ${(theme.config.post.top_thumbnail_mode == 'grid')? 'grid' : post.spec.pinned ? theme.config.post.top_thumbnail_mode : (theme.config.post.thumbnail_mode == 'grid')? 'grid' : (!#strings.isEmpty(post.metadata.annotations.get('thumbnail_mode')))? post.metadata.annotations.get('thumbnail_mode') : theme.config.post.thumbnail_mode}">
+        <!-- 1.折叠模式下：不考虑有无背景图 -->
+        <th:block th:if="${thumbnail_mode == 'fold'}">
+            <a class="card widget card-fold" th:href="${post.status.permalink}">
+                <h2 class="title"><span class="top">置顶</span>
+                    <p th:text="${post.spec.title}"></p>
+                </h2>
+                <p th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd')}"></p>
+            </a>
+        </th:block>
+        <!-- 2.非折叠模式下：考虑有无背景图? 无背景图默认样式，有背景图按自己样式处理。grid模式不处理，后续单独用容器处理 -->
+        <th:block th:unless="${thumbnail_mode == 'fold'}">
+            <th:block th:if="${#strings.isEmpty(thumbnail) || thumbnail_mode == 'default'}">
+                <div class="card widget">
+                    <a th:if="${!#strings.isEmpty(thumbnail)}" class="thumbnail" th:href="${post.status.permalink}">
+                        <div class="thumbnail-image" th:style="'background-image: url(' + ${thumbnail} + ')'">
+                        </div>
+                    </a>
+                    <div class="card-content main">
+                        <h2 class="title">
+                            <span class="top" th:if="${post.spec.pinned}">置顶</span><a th:href="${post.status.permalink}"
+                                th:text="${post.spec.title}"></a>
+                        </h2>
+                        <div class="meta">
+                            <ul class="breadcrumb">
+                                <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
+                                <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
+                                <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i
+                                        class="ri-question-answer-line"></i>[[${post.stats.comment}]]
+                                </li>
+                                <li class="is-hidden-mobile"><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]
+                                </li>
+                                <li th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
+                                    th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
+                                </li>
+                            </ul>
+                            <div th:if="${!#lists.isEmpty(post.categories)}" class="level-item">
+                                <a th:each="cy : ${post.categories}" th:href="${cy.status.permalink}"
+                                    th:text="${cy.spec.displayName}"></a>&nbsp;
+                            </div>
+                        </div>
+                        <hr />
+                        <div class="main-content" th:text="${post.status.excerpt}"></div>
+                    </div>
+                </div>
+            </th:block>
+            <th:block th:unless="${#strings.isEmpty(thumbnail) || thumbnail_mode == 'default'}">
+                <div th:if="${thumbnail_mode == 'back'}" class="card widget card-cover">
+                    <a th:href="${post.status.permalink}">
+                        <div class="cover-image" th:style="'background-image: url(' + ${thumbnail} + ')'"></div>
+                        <div class="details">
+                            <h2 class="title"><span class="top"
+                                    th:if="${post.spec.pinned}">置顶</span>[[${post.spec.title}]]</h2>
+                            <ul class="breadcrumb">
+                                <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
+                                <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
+                                <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i
+                                        class="ri-question-answer-line"></i>[[${post.stats.comment}]]
+                                </li>
+                                <li><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]</li>
+                                <li th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
+                                    th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
+                                </li>
+                            </ul>
+                        </div>
+                    </a>
+                    <div th:if="${!#lists.isEmpty(post.categories)}" class="category">
+                        <a th:each="cy : ${post.categories}" th:href="${cy.status.permalink}"
+                            th:text="${cy.spec.displayName}"></a>&nbsp;
+                    </div>
+                </div>
 
-    <div
-      th:if="${!#strings.isEmpty(thumbnail) && (thumbnail_mode == 'small' || (thumbnail_mode == 'small-alter' && postStat.index % 2 == 0))}"
-      class="card widget card-small">
-      <a th:href="${post.status.permalink}">
-        <div class="small-image" th:style="'background-image: url(' + ${thumbnail} + ')'"></div>
-      </a>
-      <div class="card-content main">
-        <h2 class="title">
-          <span class="top" th:if="${post.spec.pinned}">置顶</span><a
-          th:href="${post.status.permalink}" th:text="${post.spec.title}"></a>
-        </h2>
-        <div class="main-content" th:text="${post.status.excerpt}"></div>
-        <hr/>
-        <div class="meta">
-          <ul class="breadcrumb">
-            <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
-            <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
-            <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i class="ri-question-answer-line"></i>[[${post.stats.comment}]]
-            </li>
-            <li><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]</li>
-            <li
-              th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
-              th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
-            </li>
-          </ul>
-          <div th:if="${!#lists.isEmpty(post.categories)}" class="level-item is-hidden-mobile">
-            <a th:each="cy : ${post.categories}" th:href="${cy.status.permalink}" th:text="${cy.spec.displayName}"></a>&nbsp;
-          </div>
-        </div>
-      </div>
-    </div>
+                <div th:if="${thumbnail_mode == 'small' || (thumbnail_mode == 'small-alter' && postStat.index % 2 == 0)}"
+                    class="card widget card-small">
+                    <a th:href="${post.status.permalink}">
+                        <div class="small-image" th:style="'background-image: url(' + ${thumbnail} + ')'"></div>
+                    </a>
+                    <div class="card-content main">
+                        <h2 class="title">
+                            <span class="top" th:if="${post.spec.pinned}">置顶</span><a th:href="${post.status.permalink}"
+                                th:text="${post.spec.title}"></a>
+                        </h2>
+                        <div class="main-content" th:text="${post.status.excerpt}"></div>
+                        <hr />
+                        <div class="meta">
+                            <ul class="breadcrumb">
+                                <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
+                                <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
+                                <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i
+                                        class="ri-question-answer-line"></i>[[${post.stats.comment}]]
+                                </li>
+                                <li><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]</li>
+                                <li th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
+                                    th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
+                                </li>
+                            </ul>
+                            <div th:if="${!#lists.isEmpty(post.categories)}" class="level-item is-hidden-mobile">
+                                <a th:each="cy : ${post.categories}" th:href="${cy.status.permalink}"
+                                    th:text="${cy.spec.displayName}"></a>&nbsp;
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
-    <div
-      th:if="${!#strings.isEmpty(thumbnail) && (thumbnail_mode == 'small-right' || (thumbnail_mode == 'small-alter' && postStat.index % 2 == 1))}"
-      class="card widget card-small">
-      <div class="card-content main">
-        <h2 class="title">
-          <span class="top" th:if="${post.spec.pinned}">置顶</span><a
-          th:href="${post.status.permalink}" th:text="${post.spec.title}"></a>
-        </h2>
-        <div class="main-content" th:text="${post.status.excerpt}"></div>
-        <hr/>
-        <div class="meta">
-          <ul class="breadcrumb">
-            <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
-            <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
-            <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i class="ri-question-answer-line"></i>[[${post.stats.comment}]]
-            </li>
-            <li><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]</li>
-            <li
-              th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
-              th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
-            </li>
-          </ul>
-          <div th:if="${!#lists.isEmpty(post.categories)}" class="level-item is-hidden-mobile">
-            <a th:each="cy : ${post.categories}" th:href="${cy.status.permalink}" th:text="${cy.spec.displayName}"></a>&nbsp;
-          </div>
-        </div>
-      </div>
-      <a th:href="${post.status.permalink}">
-        <div class="small-image" th:style="'background-image: url(' + ${thumbnail} + ')'"></div>
-      </a>
-    </div>
-
-    <a th:if="${post.spec.pinned && thumbnail_mode == 'fold'}" class="card widget card-fold"
-       th:href="${post.status.permalink}">
-      <h2 class="title"><span class="top">置顶</span>
-        <p th:text="${post.spec.title}"></p></h2>
-      <p th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd')}"></p>
-    </a>
-
-    <div
-      th:if="${(#strings.isEmpty(thumbnail) && thumbnail_mode != 'fold') ||  thumbnail_mode == 'default'}"
-      class="card widget">
-      <a th:if="${!#strings.isEmpty(thumbnail)}" class="thumbnail" th:href="${post.status.permalink}">
-        <div class="thumbnail-image" th:style="'background-image: url(' + ${thumbnail} + ')'">
-        </div>
-      </a>
-      <div class="card-content main">
-        <h2 class="title">
-          <span class="top" th:if="${post.spec.pinned}">置顶</span><a
-          th:href="${post.status.permalink}" th:text="${post.spec.title}"></a>
-        </h2>
-        <div class="meta">
-          <ul class="breadcrumb">
-            <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
-            <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
-            <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i class="ri-question-answer-line"></i>[[${post.stats.comment}]]
-            </li>
-            <li class="is-hidden-mobile"><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]</li>
-            <li
-              th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
-              th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
-            </li>
-          </ul>
-          <div th:if="${!#lists.isEmpty(post.categories)}" class="level-item">
-            <a th:each="cy : ${post.categories}" th:href="${cy.status.permalink}" th:text="${cy.spec.displayName}"></a>&nbsp;
-          </div>
-        </div>
-        <hr/>
-        <div class="main-content" th:text="${post.status.excerpt}"></div>
-      </div>
-    </div>
-  </th:block>
-  <div th:if="${theme.config.post.top_thumbnail_mode == 'grid' || theme.config.post.thumbnail_mode == 'grid'}"
-       class="column-main-grid">
-    <th:block th:each="post : ${posts}"
-              th:with="thumbnail = ${#strings.isEmpty(post.spec.cover) ? #strings.isEmpty(theme.config.post.default_thumbnail) ? '' : theme.config.post.default_thumbnail + (#strings.contains(theme.config.post.default_thumbnail, '?') ? '&' : '?') + 'id=' + post.metadata.name : post.spec.cover}">
-      <div
-        th:if="${(theme.config.post.top_thumbnail_mode == 'grid' || (!post.spec.pinned && theme.config.post.thumbnail_mode == 'grid'))}"
-        class="card widget">
-        <a class="thumbnail" th:href="${post.status.permalink}">
-          <div class="thumbnail-image" th:style="'background-image: url(' + ${thumbnail} + ')'"></div>
-        </a>
-        <ul class="breadcrumb">
-          <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
-          <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
-          <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i class="ri-question-answer-line"></i>[[${post.stats.comment}]]
-          </li>
-          <li class="is-hidden-mobile"><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]</li>
-          <li
-            th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
-            th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
-          </li>
-        </ul>
-        <h2 class="title">
-          <span class="top" th:if="${post.spec.pinned}">置顶</span>
-          <a
-            th:href="${post.status.permalink}" th:text="${post.spec.title}"></a>
-        </h2>
-      </div>
+                <div th:if="${thumbnail_mode == 'small-right' || (thumbnail_mode == 'small-alter' && postStat.index % 2 == 1)}"
+                    class="card widget card-small">
+                    <div class="card-content main">
+                        <h2 class="title">
+                            <span class="top" th:if="${post.spec.pinned}">置顶</span><a th:href="${post.status.permalink}"
+                                th:text="${post.spec.title}"></a>
+                        </h2>
+                        <div class="main-content" th:text="${post.status.excerpt}"></div>
+                        <hr />
+                        <div class="meta">
+                            <ul class="breadcrumb">
+                                <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
+                                <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
+                                <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i
+                                        class="ri-question-answer-line"></i>[[${post.stats.comment}]]
+                                </li>
+                                <li><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]</li>
+                                <li th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
+                                    th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
+                                </li>
+                            </ul>
+                            <div th:if="${!#lists.isEmpty(post.categories)}" class="level-item is-hidden-mobile">
+                                <a th:each="cy : ${post.categories}" th:href="${cy.status.permalink}"
+                                    th:text="${cy.spec.displayName}"></a>&nbsp;
+                            </div>
+                        </div>
+                    </div>
+                    <a th:href="${post.status.permalink}">
+                        <div class="small-image" th:style="'background-image: url(' + ${thumbnail} + ')'"></div>
+                    </a>
+                </div>
+            </th:block>
+        </th:block>
     </th:block>
-  </div>
+
+    <div class="column-main-grid">
+        <th:block th:each="post : ${posts}" 
+                  th:with="thumbnail = ${!#strings.isEmpty(post.spec.cover) ? post.spec.cover : (#strings.isEmpty(theme.config.post.default_thumbnail) ? '' : theme.config.post.default_thumbnail + (#strings.contains(theme.config.post.default_thumbnail, '?') ? '&' : '?') + 'id=' + post.metadata.name)}, 
+                           thumbnail_mode = ${(theme.config.post.top_thumbnail_mode == 'grid')? 'grid' : post.spec.pinned ? theme.config.post.top_thumbnail_mode : (theme.config.post.thumbnail_mode == 'grid')? 'grid' : (!#strings.isEmpty(post.metadata.annotations.get('thumbnail_mode')))? post.metadata.annotations.get('thumbnail_mode') : theme.config.post.thumbnail_mode}">
+                <!-- 仅筛选 grid 布局模式的帖子：无论是包含置顶还是非置顶帖子 -->
+                <div th:if="${thumbnail_mode == 'grid'}" class="card widget">
+                <a class="thumbnail" th:href="${post.status.permalink}">
+                    <div class="thumbnail-image" th:style="'background-image: url(' + ${thumbnail} + ')'"></div>
+                </a>
+                <ul class="breadcrumb">
+                    <li th:text="${#dates.format(post.spec.publishTime, 'yyyy-MM-dd HH:mm')}"></li>
+                    <li><i class="ri-eye-line"></i>[[${post.stats.visit}]]</li>
+                    <li th:if="${post.spec.allowComment}" class="is-hidden-mobile"><i
+                            class="ri-question-answer-line"></i>[[${post.stats.comment}]]
+                    </li>
+                    <li class="is-hidden-mobile"><i class="ri-thumb-up-line"></i>[[${post.stats.upvote}]]</li>
+                    <li th:with="heat= ${24+post.stats.visit*0.1+post.stats.upvote*2+post.stats.comment*3}, heatColor= '#'+${(heat < 37)? 'ffa87e' : (heat < 120)? 'fb734a' : 'e0081c'}"
+                        th:style="'color: ' + ${heatColor}">[[${#numbers.formatDecimal(heat,0,1)}]]℃
+                    </li>
+                </ul>
+                <h2 class="title">
+                    <span class="top" th:if="${post.spec.pinned}">置顶</span>
+                    <a th:href="${post.status.permalink}" th:text="${post.spec.title}"></a>
+                </h2>
+            </div>
+        </th:block>
+    </div>
+
 </th:block>


### PR DESCRIPTION
改动：
* index.html 修复一个变量命名的疏漏
* article_list.html 修改代码逻辑，提高可读性
   建议：感觉这个位置看起来逻辑比较混乱的原因主要是两点：第一，把“文章卡片缩略图的位置”和“文章列表布局样式”杂糅在一起所致，前者是缩略图在文章卡片中的相对位置或者说文章卡片的样式，后者是各个文章卡片在文章列表中是怎么布局的。所以这个 grid 判断优先级让整个逻辑看起来会有点怪怪的。第二，自由度太高。给文章添加了单独的缩略图样式字段，这样的设计初衷可能是为了给大家更多的定制化，但这可能是没有必要的。因为一般情况下的审美应该是文章卡片按某种规律展示，比如缩略图全在左、在右或交替，而不是自己定制让每个文章卡片都不一样，后续可以考虑收回这部分定制的权利和字段。