### PR TITLE
fix：修复SW未过滤浏览器插件请求引发的控制台报错

### DIFF
--- a/src/js/sw.js
+++ b/src/js/sw.js
@@ -167,6 +167,10 @@
         || isExitInUrlList(notHandleList, event.request.url)) {
         return false
       }
+      // 检查请求协议是否为 http 或 https
+      if (!event.request.url.startsWith('http://') && !event.request.url.startsWith('https://')) {
+        return false
+      }
       const isCdnAndCache = isExitInUrlList(cdnAndCacheList, event.request.url)
       const isOnlyCacheList = isExitInUrlList(onlyCacheList, event.request.url)
       // cdn并发请求未开启 或 请求没有被任何路由命中

--- a/templates/common/head.html
+++ b/templates/common/head.html
@@ -1,7 +1,7 @@
 <head xmlns:th="https://www.thymeleaf.org" th:fragment="head"
 th:with="description=${isPost ? post != null ? post.status.excerpt : singlePage != null ? singlePage.status.excerpt : site.seo.description : site.seo.description}">
   <title th:text="${title + (#strings.isEmpty(site.subtitle) ? '' : '|' + site.subtitle)}"></title>
-  <script th:if="${theme.config.enhance.enable_sw}" th:src="${(theme.config.enhance.enable_sw == 'uninstall')? #theme.assets('/assets/js/sw.min.js?uninstall=true') + '&mew=1.2.1' : '/sw.min.js?mew=1.2.1' + theme.config.enhance.enable_sw + '&cdn=' + theme.config.enhance.sw_cdn_source.replaceAll('\n', ',')}"></script>
+  <script th:if="${theme.config.enhance.enable_sw}" th:src="${(theme.config.enhance.enable_sw == 'uninstall')? #theme.assets('/js/sw.min.js?uninstall=true') + '&mew=1.2.2' : '/sw.min.js?mew=1.2.2' + theme.config.enhance.enable_sw + '&cdn=' + theme.config.enhance.sw_cdn_source.replaceAll('\n', ',')}"></script>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
   <meta http-equiv="x-dns-prefetch-control" content="on">


### PR DESCRIPTION
### fix：修复卸载sw时引用的路径不正确；
### fix：修复SW未过滤浏览器插件请求引发的控制台报错
- 主要对非http(s)请求的路径不执行缓存
